### PR TITLE
refactor(all): Update openzeppelin contracts and add EIP1271 to ERC20Guild

### DIFF
--- a/contracts/dxvote/DXDGuild.sol
+++ b/contracts/dxvote/DXDGuild.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 pragma experimental ABIEncoderV2;
 
 import "../erc20guild/ERC20Guild.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
 /// @title DXDGuild
 /// @author github:AugustoL

--- a/contracts/dxvote/utils/DXdaoNFT.sol
+++ b/contracts/dxvote/utils/DXdaoNFT.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract DXdaoNFT is ERC721, Ownable {
+contract DXdaoNFT is ERC721URIStorage, Ownable {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 

--- a/contracts/erc20guild/IERC20Guild.sol
+++ b/contracts/erc20guild/IERC20Guild.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
@@ -45,6 +46,8 @@ interface IERC20Guild {
         bytes4[] calldata functionSignature,
         bool[] calldata allowance
     ) external;
+    
+    function setEIP1271SignedHash(bytes32 _hash, bool isValid) external;
 
     function createProposal(
         address[] calldata to,
@@ -153,6 +156,15 @@ interface IERC20Guild {
         external
         view
         returns (bool);
+        
+    function getProposalsIdsLength() external view returns (uint256);
+
+    function getEIP1271SignedHash(bytes32 _hash) external view returns (bool);
+    
+    function isValidSignature(bytes32 hash, bytes memory signature)
+        external
+        view
+        returns (bytes4 magicValue);
 
     function votingPowerOf(address account) external view returns (uint256);
 

--- a/contracts/omen/OMNGuild.sol
+++ b/contracts/omen/OMNGuild.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 pragma experimental ABIEncoderV2;
 
 import "../erc20guild/ERC20Guild.sol";
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "../realitio/IRealitio.sol";
 
 /// @title OMNGuild - OMEN Token ERC20Guild

--- a/contracts/omen/OMNToken.sol
+++ b/contracts/omen/OMNToken.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";

--- a/contracts/realitio/IRealitio.sol
+++ b/contracts/realitio/IRealitio.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 
 interface IRealitio {
   function claimWinnings ( bytes32 question_id, bytes32[] calldata history_hashes, address[] calldata addrs, uint256[] calldata bonds, bytes32[] calldata answers ) external;

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 
 library Arrays {
   

--- a/contracts/utils/ETHRelayer.sol
+++ b/contracts/utils/ETHRelayer.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
+
 
 /**
  * @title ETHRelayer

--- a/contracts/utils/TokenVault.sol
+++ b/contracts/utils/TokenVault.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.8;
 
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 /**

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -79,6 +79,15 @@ module.exports = {
   solidity: {
     compilers: [
       {
+        version: '0.4.25',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+      {
         version: '0.5.17',
         settings: {
           optimizer: {
@@ -97,7 +106,7 @@ module.exports = {
         },
       },
       {
-        version: '0.4.25',
+        version: '0.7.6',
         settings: {
           optimizer: {
             enabled: true,
@@ -106,32 +115,32 @@ module.exports = {
         },
       },
       {
-        version: '0.7.6',
+        version: '0.8.8',
         settings: {
           optimizer: {
             enabled: true,
-            runs: 200,
-          },
-        },
-      },
+            runs: 200
+          }
+        }
+      }
     ],
     overrides: {
       'contracts/utils/GnosisSafe/GnosisProxy.sol': { version: '0.5.14' },
       'contracts/utils/GnosisSafe/GnosisSafe.sol': { version: '0.5.14' },
-      'contracts/omen/OMNToken.sol': { version: '0.7.6' },
+      'contracts/omen/OMNToken.sol': { version: '0.8.8' },
       'contracts/omen/OMNGuild.sol': {
-        version: '0.7.6',
+        version: '0.8.8',
         settings: { optimizer: { enabled: true, runs: 100 } },
       },
       'contracts/dxdao/DXDGuild.sol': {
-        version: '0.7.6',
+        version: '0.8.8',
         settings: { optimizer: { enabled: true, runs: 100 } },
       },
       'contracts/erc20guild/ERC20Guild.sol': {
-        version: '0.7.6',
+        version: '0.8.8',
         settings: { optimizer: { enabled: true, runs: 100 } },
       },
-      'contracts/erc20guild/IERC20Guild.sol': { version: '0.7.6' },
+      'contracts/erc20guild/IERC20Guild.sol': { version: '0.8.8' },
     },
   },
   gasReporter: {

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   "dependencies": {
     "@daostack/infra": "0.0.1-rc.19",
     "@maticnetwork/eth-decoder": "0.0.2",
-    "@openzeppelin/contracts": "3.4.0",
-    "@openzeppelin/contracts-upgradeable": "3.4.0",
+    "@openzeppelin/contracts": "4.3.2",
+    "@openzeppelin/contracts-upgradeable": "4.3.2",
     "@openzeppelin/test-helpers": "^0.5.11",
     "@realitio/realitio-contracts": ">=0.0.0",
     "@truffle/hdwallet-provider": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,15 +1669,15 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
 
-"@openzeppelin/contracts-upgradeable@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.0.tgz#7674c73c643a509f1b90c509e3e72fe9aae02aeb"
-  integrity sha512-7wBcbukDqWZt/B1zjb7zyeWq+AC7rx7nGln7/hPxHdKd8PAiiteXd51Cp2KmGP8qaY0/TXh/fQLsA082LWp8Zw==
+"@openzeppelin/contracts-upgradeable@4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz#92df481362e366c388fc02133cf793029c744cea"
+  integrity sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ==
 
-"@openzeppelin/contracts@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0.tgz#9a1669ad5f9fdfb6e273bb5a4fed10cb4cc35eb0"
-  integrity sha512-qh+EiHWzfY/9CORr+eRUkeEUP1WiFUcq3974bLHwyYzLBUtK6HPaMkIUHi74S1rDTZ0sNz42DwPc5A4IJvN3rg==
+"@openzeppelin/contracts@4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
+  integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
 
 "@openzeppelin/hardhat-upgrades@^1.6.0":
   version "1.10.0"


### PR DESCRIPTION
- Updated openzeppelin smart contract libraries to 4.3.2 that includes EIP1271 smart contracts.
- Updated smart contracts that are not part of dxvote stack yet to solidity 0.8.8.
- Added EIP1271 support to ERC20Guilds with tests.