### PR TITLE
Fix vote params in WalletScheme

### DIFF
--- a/contracts/dxvote/WalletScheme.sol
+++ b/contracts/dxvote/WalletScheme.sol
@@ -38,7 +38,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
         None,
         Submitted,
         Rejected,
-        ExecutionSucceded,
+        ExecutionSucceeded,
         ExecutionTimeout
     }
 
@@ -65,7 +65,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     uint256 public maxRepPercentageChange;
 
     // This mapping is used as "memory storage" in executeProposal function, to keep track of the total value
-    // transfered of by asset and address, it saves both aseet and address as keccak256(asset, recipient)
+    // transfered of by asset and address, it saves both asset and address as keccak256(asset, recipient)
     mapping(bytes32 => uint256) internal valueTransferedByAssetAndRecipient;
 
     // This mapping is used as "memory storage" in executeProposal function, to keep track of the total value
@@ -372,7 +372,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
                     "WalletScheme: call execution failed"
                 );
             }
-            // Cant mint or burn more REP than the allowed percentaje set in the wallet scheme initialization
+            // Cant mint or burn more REP than the allowed percentaged set in the wallet scheme initialization
             require(
                 (oldRepSupply.mul(uint256(100).add(maxRepPercentageChange)).div(
                     100
@@ -389,10 +389,10 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
                     permissionHashUsed[i]
                 ];
             }
-            proposal.state = ProposalState.ExecutionSucceded;
+            proposal.state = ProposalState.ExecutionSucceeded;
             emit ProposalStateChange(
                 _proposalId,
-                uint256(ProposalState.ExecutionSucceded)
+                uint256(ProposalState.ExecutionSucceeded)
             );
             emit ExecutionResults(
                 _proposalId,
@@ -543,7 +543,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
 
     /**
      * @dev Decodes abi encoded data with selector for "transfer(address,uint256)".
-     * @param _data ERC20 addres and value encoded data.
+     * @param _data ERC20 address and value encoded data.
      * @return to The account to receive the tokens
      * @return value The value of tokens to be transfered/approved
      */

--- a/contracts/dxvote/WalletScheme.sol
+++ b/contracts/dxvote/WalletScheme.sol
@@ -5,6 +5,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "@daostack/infra/contracts/votingMachines/IntVoteInterface.sol";
 import "@daostack/infra/contracts/votingMachines/ProposalExecuteInterface.sol";
 import "../daostack/votingMachines/VotingMachineCallbacks.sol";
+import "../daostack/controller/ControllerInterface.sol";
 import "./PermissionRegistry.sol";
 
 /**
@@ -22,7 +23,7 @@ import "./PermissionRegistry.sol";
 contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     using SafeMath for uint256;
 
-    string public SCHEME_TYPE = "Wallet Scheme v1";
+    string public SCHEME_TYPE = "Wallet Scheme v1.1";
     bytes4 public constant ERC20_TRANSFER_SIGNATURE =
         bytes4(keccak256("transfer(address,uint256)"));
     bytes4 public constant ERC20_APPROVE_SIGNATURE =
@@ -55,9 +56,9 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     bytes32[] public proposalsList;
 
     IntVoteInterface public votingMachine;
-    bytes32 public voteParams;
+    bool public doAvatarGenericCalls;
     Avatar public avatar;
-    address public controllerAddress;
+    ControllerInterface public controller;
     PermissionRegistry public permissionRegistry;
     string public schemeName;
     uint256 public maxSecondsForExecution;
@@ -88,9 +89,8 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
      * @dev initialize
      * @param _avatar the avatar address
      * @param _votingMachine the voting machines address to
-     * @param _voteParams voting machine parameters.
-     * @param _controllerAddress The address to receive the calls, if address 0x0 is used it wont make generic calls
-     * to the avatar
+     * @param _doAvatarGenericCalls is the scheme will do generic calls form the avatar
+     * @param _controller The controller address
      * @param _permissionRegistry The address of the permission registry contract
      * @param _maxSecondsForExecution The maximum amount of time in seconds  for a proposal without executed since
      * submitted time
@@ -100,8 +100,8 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     function initialize(
         Avatar _avatar,
         IntVoteInterface _votingMachine,
-        bytes32 _voteParams,
-        address _controllerAddress,
+        bool _doAvatarGenericCalls,
+        address _controller,
         address _permissionRegistry,
         string calldata _schemeName,
         uint256 _maxSecondsForExecution,
@@ -109,14 +109,15 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     ) external {
         require(avatar == Avatar(0), "WalletScheme: cannot init twice");
         require(_avatar != Avatar(0), "WalletScheme: avatar cannot be zero");
+        require(_controller != address(0), "WalletScheme: controller cannot be zero");
         require(
             _maxSecondsForExecution >= 86400,
             "WalletScheme: _maxSecondsForExecution cant be less than 86400 seconds"
         );
         avatar = _avatar;
         votingMachine = _votingMachine;
-        voteParams = _voteParams;
-        controllerAddress = _controllerAddress;
+        doAvatarGenericCalls = _doAvatarGenericCalls;
+        controller = ControllerInterface(_controller);
         permissionRegistry = PermissionRegistry(_permissionRegistry);
         schemeName = _schemeName;
         maxSecondsForExecution = _maxSecondsForExecution;
@@ -128,7 +129,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
      */
     function() external payable {
         require(
-            controllerAddress == address(0),
+            !doAvatarGenericCalls,
             "WalletScheme: Cant receive if it will make generic calls to avatar"
         );
     }
@@ -260,7 +261,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
             for (uint256 i = 0; i < assetsUsed.length; i++) {
                 (_valueAllowed, _fromTime) = permissionRegistry.getPermission(
                     assetsUsed[i],
-                    controllerAddress != address(0)
+                    doAvatarGenericCalls
                         ? address(avatar)
                         : address(this),
                     address(this),
@@ -291,7 +292,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
                     (_valueAllowed, _fromTime) = permissionRegistry
                         .getPermission(
                         proposal.to[i],
-                        controllerAddress != address(0)
+                        doAvatarGenericCalls
                             ? address(avatar)
                             : address(this),
                         _to,
@@ -308,7 +309,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
                     (_valueAllowed, _fromTime) = permissionRegistry
                         .getPermission(
                         address(0),
-                        controllerAddress != address(0)
+                        doAvatarGenericCalls
                             ? address(avatar)
                             : address(this),
                         proposal.to[i],
@@ -334,8 +335,8 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
 
                 // If controller address is set the code needs to be encoded to generiCall function
                 if (
-                    controllerAddress != address(0) &&
-                    proposal.to[i] != controllerAddress
+                    doAvatarGenericCalls &&
+                    proposal.to[i] != address(controller)
                 ) {
                     bytes memory genericCallData =
                         abi.encodeWithSignature(
@@ -346,7 +347,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
                             proposal.value[i]
                         );
                     (callsSucessResult[i], callsDataResult[i]) = address(
-                        controllerAddress
+                        controller
                     )
                         .call
                         .value(0)(genericCallData);
@@ -466,6 +467,8 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
             _to.length == _value.length,
             "WalletScheme: invalid _value length"
         );
+
+        bytes32 voteParams = controller.getSchemeParameters(address(this), address(avatar));
 
         // Get the proposal id that will be used from the voting machine
         bytes32 proposalId =

--- a/test/dxdao/dxdao.js
+++ b/test/dxdao/dxdao.js
@@ -89,7 +89,7 @@ contract("DXdao", function (accounts) {
     await masterWalletScheme.initialize(
       avatar.address,
       votingMachine.address,
-      votingMachine.params,
+      true,
       controller.address,
       permissionRegistry.address,
       "Master Scheme",

--- a/test/dxvote/DXDVotingMachine.js
+++ b/test/dxvote/DXDVotingMachine.js
@@ -85,7 +85,7 @@ contract("DXDVotingMachine", function (accounts) {
     await expensiveVoteWalletScheme.initialize(
       org.avatar.address,
       genVotingMachine.address,
-      genVotingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Expensive Scheme",
@@ -97,7 +97,7 @@ contract("DXDVotingMachine", function (accounts) {
     await cheapVoteWalletScheme.initialize(
       org.avatar.address,
       dxdVotingMachine.address,
-      dxdVotingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Cheap Scheme",

--- a/test/dxvote/PermissionRegistry.js
+++ b/test/dxvote/PermissionRegistry.js
@@ -60,7 +60,7 @@ contract("PermissionRegistry", function (accounts) {
     await masterWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Master Wallet",
@@ -72,8 +72,8 @@ contract("PermissionRegistry", function (accounts) {
     await quickWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
-      constants.NULL_ADDRESS,
+      false,
+      org.controller.address,
       permissionRegistry.address,
       "Quick Wallet",
       executionTimeout,

--- a/test/dxvote/Utils.js
+++ b/test/dxvote/Utils.js
@@ -59,7 +59,7 @@ contract("Dxvote Utils", function (accounts) {
     await masterWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Master Wallet",
@@ -71,8 +71,8 @@ contract("Dxvote Utils", function (accounts) {
     await quickWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
-      constants.NULL_ADDRESS,
+      false,
+      org.controller.address,
       permissionRegistry.address,
       "Quick Wallet",
       executionTimeout,

--- a/test/dxvote/WalletScheme.js
+++ b/test/dxvote/WalletScheme.js
@@ -563,6 +563,20 @@ contract("WalletScheme", function (accounts) {
       ),
       newVotingParamsHash
     );
+
+    // Test that the masterWalletScheme now will submit proposals with new voting configuration
+    const submitProposalTx = await masterWalletScheme.proposeCalls(
+      [accounts[1]],
+      ["0x00"],
+      [1],
+      constants.TEST_TITLE,
+      constants.SOME_HASH
+    );
+    assert.equal(
+      helpers.logDecoder.decodeLogs(submitProposalTx.receipt.rawLogs)[0].args._paramsHash,
+      newVotingParamsHash
+    );
+
   });
 
   it("MasterWalletScheme - setMaxSecondsForExecution is callable only form the avatar", async function () {

--- a/test/dxvote/WalletScheme.js
+++ b/test/dxvote/WalletScheme.js
@@ -67,7 +67,7 @@ contract("WalletScheme", function (accounts) {
     await registrarWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Wallet Scheme Registrar",
@@ -79,7 +79,7 @@ contract("WalletScheme", function (accounts) {
     await masterWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
+      true,
       org.controller.address,
       permissionRegistry.address,
       "Master Wallet",
@@ -91,8 +91,8 @@ contract("WalletScheme", function (accounts) {
     await quickWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
-      constants.NULL_ADDRESS,
+      false,
+      org.controller.address,
       permissionRegistry.address,
       "Quick Wallet",
       executionTimeout,
@@ -217,8 +217,8 @@ contract("WalletScheme", function (accounts) {
     await newWalletScheme.initialize(
       org.avatar.address,
       votingMachine.address,
-      votingMachine.params,
-      constants.NULL_ADDRESS,
+      false,
+      org.controller.address,
       permissionRegistry.address,
       "New Wallet",
       executionTimeout,
@@ -2058,8 +2058,8 @@ contract("WalletScheme", function (accounts) {
       unitializedWalletScheme.initialize(
         org.avatar.address,
         accounts[0],
-        accounts[0],
-        constants.NULL_ADDRESS,
+        false,
+        org.controller.address,
         permissionRegistry.address,
         "Master Wallet",
         86400 - 1,
@@ -2071,8 +2071,8 @@ contract("WalletScheme", function (accounts) {
       unitializedWalletScheme.initialize(
         constants.NULL_ADDRESS,
         accounts[0],
-        accounts[0],
-        constants.NULL_ADDRESS,
+        false,
+        org.controller.address,
         permissionRegistry.address,
         "Master Wallet",
         executionTimeout,
@@ -2087,8 +2087,8 @@ contract("WalletScheme", function (accounts) {
       masterWalletScheme.initialize(
         org.avatar.address,
         accounts[0],
-        accounts[0],
-        constants.NULL_ADDRESS,
+        false,
+        org.controller.address,
         permissionRegistry.address,
         "Master Wallet",
         executionTimeout,


### PR DESCRIPTION
A bug was found in the WalletScheme regarding the voting parameters used for the proposal submission, the voteParams variable was only set in the inializer and if the voting parameters for the scheme changed in the controller the change was not reflected in the WalletScheme, so it will only submit proposals with the original voting parameters.

The changes done :
1.- Change `voteParams` for a variable called `doAvatarGenericCall` and require the controller address to always be set, this the wallet scheme will always get the voting parameters of the scheme by calling `controller.getSchemeParameters(schemeAddress,avatarAddress)` and instead of checking if controller address was zero to know if it had to make generic calls or not it will use the `doAvatarGenericCall` value.
2.- Since I was doing these changes I also fixed some typos in the WalletScheme contract.
3.- Did a small change in all tests in the initialize function and all tests run like before, like it was expected.
4.- Add tests to test the change of voting parameters work when new proposals are created.