### PR TITLE
DXDVotingMachineCallbaks for WalletScheme

### DIFF
--- a/contracts/daostack/votingMachines/DXDVotingMachineCallbacks.sol
+++ b/contracts/daostack/votingMachines/DXDVotingMachineCallbacks.sol
@@ -1,0 +1,61 @@
+pragma solidity ^0.5.4;
+
+import "../controller/ControllerInterface.sol";
+import "../controller/Avatar.sol";
+import "./VotingMachineCallbacksInterface.sol";
+import "@daostack/infra/contracts/votingMachines/IntVoteInterface.sol";
+
+
+contract DXDVotingMachineCallbacks is VotingMachineCallbacksInterface {
+
+    IntVoteInterface public votingMachine;
+    Avatar public avatar;
+
+    modifier onlyVotingMachine() {
+        require(msg.sender == address(votingMachine), "only VotingMachine");
+        _;
+    }
+
+    // proposalId  ->  block number
+    mapping(bytes32 => uint256) public proposalsBlockNumber;
+
+    function mintReputation(uint256 _amount, address _beneficiary, bytes32 _proposalId)
+    external
+    onlyVotingMachine()
+    returns(bool)
+    {
+        return ControllerInterface(avatar.owner()).mintReputation(_amount, _beneficiary, address(avatar));
+    }
+
+    function burnReputation(uint256 _amount, address _beneficiary, bytes32 _proposalId)
+    external
+    onlyVotingMachine()
+    returns(bool)
+    {
+        return ControllerInterface(avatar.owner()).burnReputation(_amount, _beneficiary, address(avatar));
+    }
+
+    function stakingTokenTransfer(
+        IERC20 _stakingToken,
+        address _beneficiary,
+        uint256 _amount,
+        bytes32 _proposalId)
+    external
+    onlyVotingMachine()
+    returns(bool)
+    {
+        return ControllerInterface(avatar.owner()).externalTokenTransfer(_stakingToken, _beneficiary, _amount, avatar);
+    }
+
+    function balanceOfStakingToken(IERC20 _stakingToken, bytes32 _proposalId) external view returns(uint256) {
+        return _stakingToken.balanceOf(address(avatar));
+    }
+
+    function getTotalReputationSupply(bytes32 _proposalId) external view returns(uint256) {
+        return Avatar(avatar).nativeReputation().totalSupplyAt(proposalsBlockNumber[_proposalId]);
+    }
+
+    function reputationOf(address _owner, bytes32 _proposalId) external view returns(uint256) {
+        return Avatar(avatar).nativeReputation().balanceOfAt(_owner, proposalsBlockNumber[_proposalId]);
+    }
+}

--- a/contracts/dxvote/WalletScheme.sol
+++ b/contracts/dxvote/WalletScheme.sol
@@ -2,10 +2,8 @@ pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "@daostack/infra/contracts/votingMachines/IntVoteInterface.sol";
 import "@daostack/infra/contracts/votingMachines/ProposalExecuteInterface.sol";
-import "../daostack/votingMachines/VotingMachineCallbacks.sol";
-import "../daostack/controller/ControllerInterface.sol";
+import "../daostack/votingMachines/DXDVotingMachineCallbacks.sol";
 import "./PermissionRegistry.sol";
 
 /**
@@ -20,7 +18,7 @@ import "./PermissionRegistry.sol";
  * The permissions for [asset][SCHEME_ADDRESS][ANY_SIGNATURE] are used for global transfer limit, if it is set,
  * it wont allowed a higher total value transfered in the proposal higher to the one set there.
  */
-contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
+contract WalletScheme is DXDVotingMachineCallbacks, ProposalExecuteInterface {
     using SafeMath for uint256;
 
     string public SCHEME_TYPE = "Wallet Scheme v1.1";
@@ -55,9 +53,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
     mapping(bytes32 => Proposal) public proposals;
     bytes32[] public proposalsList;
 
-    IntVoteInterface public votingMachine;
     bool public doAvatarGenericCalls;
-    Avatar public avatar;
     ControllerInterface public controller;
     PermissionRegistry public permissionRegistry;
     string public schemeName;
@@ -161,7 +157,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
      */
     function executeProposal(bytes32 _proposalId, int256 _decision)
         external
-        onlyVotingMachine(_proposalId)
+        onlyVotingMachine()
         returns (bool)
     {
         require(
@@ -485,10 +481,7 @@ contract WalletScheme is VotingMachineCallbacks, ProposalExecuteInterface {
             submittedTime: now
         });
         proposalsList.push(proposalId);
-        proposalsInfo[address(votingMachine)][proposalId] = ProposalInfo({
-            blockNumber: block.number,
-            avatar: avatar
-        });
+        proposalsBlockNumber[proposalId] = block.number;
         emit ProposalStateChange(proposalId, uint256(ProposalState.Submitted));
         return proposalId;
     }


### PR DESCRIPTION
The previous WalletScheme contract was throwing stack too deep compilation error due to lot of unnecessary imports in the VotingMachineCallbacks contract so I wrote the DXDVotingMachineCallback smart contract that does not import the entire voting machine code and only use one avatar address and keeps track of the block number for each proposal creation.

This smart contract called callback expose methods that are used by the voting machine smart contract and since we wont use universal schemes like daostack did, we dont need to save the avatar address for each proposal and we dont need to import that much code in the callback contract. The changes done are minimal, all tests works like it did before.