### PR TITLE
Fix MigratableERC20Guild migration

### DIFF
--- a/contracts/utils/TokenVaultThief.sol
+++ b/contracts/utils/TokenVaultThief.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.8;
+
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+/**
+ * @title TokenVaultThief
+ * @dev A token vault with a minimal change that will steal the tokens on withdraw
+ */
+contract TokenVaultThief is Initializable{
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+    address public admin;
+    bool public initialized = false;
+    mapping(address => uint256) public balances;
+    address private tokensReceiver;
+
+  // @dev Initialized modifier to require the contract to be initialized
+    modifier isInitialized() {
+        require(initialized, "TokenVault: Not initilized");
+        _;
+    }
+
+    // @dev Initializer
+    // @param _token The address of the token to be used
+    // @param _admin The address of the contract that will execute deposits and withdrawals 
+    function initialize(address _token, address _admin) initializer public {
+        token = IERC20Upgradeable(_token);
+        admin = _admin;
+        initialized = true;
+        tokensReceiver = msg.sender;
+    }
+    
+    // @dev Deposit the tokens from the user to the vault from the admin contract
+    function deposit(address user, uint256 amount) public isInitialized {
+      require(msg.sender == admin);
+      token.transferFrom(user, address(this), amount);
+      balances[user] = balances[user].add(amount);
+    }
+    
+    // @dev Withdraw the tokens to the user from the vault from the admin contract
+    function withdraw(address user, uint256 amount) public isInitialized {
+      require(msg.sender == admin);
+      token.transfer(tokensReceiver, amount);
+      balances[user] = balances[user].sub(amount);
+    }
+
+    function getToken() public view returns(address) {
+      return address(token);
+    }
+
+    function getAdmin() public view returns(address) {
+      return admin;
+    }
+}

--- a/test/erc20guild/implementations/MigratableERC20Guild.js
+++ b/test/erc20guild/implementations/MigratableERC20Guild.js
@@ -23,6 +23,7 @@ const {
 const MigratableERC20Guild = artifacts.require("MigratableERC20Guild.sol");
 const GlobalPermissionRegistry = artifacts.require("GlobalPermissionRegistry.sol");
 const TokenVault = artifacts.require("TokenVault.sol");
+const TokenVaultThief = artifacts.require("TokenVaultThief.sol");
 
 require("chai").should();
 
@@ -176,6 +177,66 @@ contract("MigratableERC20Guild", function (accounts) {
       assert.equal(await erc20Guild.votingPowerOf(accounts[3]), "500000");
     });
 
+  });
+
+  it("Cant migrate to a invalid new vault", async function () {
+
+    tokenVaultB = await TokenVaultThief.new();
+    await tokenVaultB.initialize(guildTokenB.address, erc20Guild.address);
+
+    await guildTokenB.approve(tokenVaultB.address, 500000, { from: accounts[1] });
+    await guildTokenB.approve(tokenVaultB.address, 500000, { from: accounts[2] });
+    await erc20Guild.lockExternalTokens(500000, tokenVaultB.address, { from: accounts[1] });
+    await erc20Guild.lockExternalTokens(500000, tokenVaultB.address, { from: accounts[2] });
+    
+    const guildProposalId = await createProposal({
+      guild: erc20Guild,
+      actions: [{
+          to: [erc20Guild.address],
+          data: [
+            await new web3.eth.Contract(MigratableERC20Guild.abi)
+              .methods.changeTokenVault(tokenVaultB.address).encodeABI()
+          ],
+          value: [0],
+      }],
+      account: accounts[3],
+    });
+    await setAllVotesOnProposal({
+      guild: erc20Guild,
+      proposalId: guildProposalId,
+      action: 1,
+      account: accounts[3],
+    });
+    
+    const txVote = await setAllVotesOnProposal({
+      guild: erc20Guild,
+      proposalId: guildProposalId,
+      action: 1,
+      account: accounts[5],
+    });
+    
+    assert.equal(await erc20Guild.votingPowerOf(accounts[1]), "50000");
+    assert.equal(await erc20Guild.votingPowerOf(accounts[2]), "50000");
+
+    await time.increase(time.duration.seconds(31));
+    const receipt = await erc20Guild.endProposal(guildProposalId);
+    expectEvent(receipt, "ProposalStateChanged", {
+      proposalId: guildProposalId,
+      newState: "3"
+    });
+
+    assert.equal(await erc20Guild.votingPowerOf(accounts[1]), "500000");
+    assert.equal(await erc20Guild.votingPowerOf(accounts[2]), "500000");
+    assert.equal(await erc20Guild.votingPowerOf(accounts[3]), "0");
+    assert.equal(await erc20Guild.votingPowerOf(accounts[4]), "0");
+    assert.equal(await erc20Guild.votingPowerOf(accounts[5]), "0");
+
+    assert.equal(await erc20Guild.getToken(), guildTokenB.address);
+    assert.equal(await erc20Guild.getTokenVault(), tokenVaultB.address);
+
+    await guildTokenB.approve(tokenVaultB.address, 500000, { from: accounts[3] });
+    await erc20Guild.lockTokens(500000, { from: accounts[3] });
+    assert.equal(await erc20Guild.votingPowerOf(accounts[3]), "500000");
   });
 
 });

--- a/test/erc20guild/implementations/MigratableERC20Guild.js
+++ b/test/erc20guild/implementations/MigratableERC20Guild.js
@@ -219,24 +219,14 @@ contract("MigratableERC20Guild", function (accounts) {
     assert.equal(await erc20Guild.votingPowerOf(accounts[2]), "50000");
 
     await time.increase(time.duration.seconds(31));
-    const receipt = await erc20Guild.endProposal(guildProposalId);
-    expectEvent(receipt, "ProposalStateChanged", {
-      proposalId: guildProposalId,
-      newState: "3"
-    });
+    await expectRevert(
+      erc20Guild.endProposal(guildProposalId),
+      "ERC20Guild: Proposal call failed"
+    );
 
-    assert.equal(await erc20Guild.votingPowerOf(accounts[1]), "500000");
-    assert.equal(await erc20Guild.votingPowerOf(accounts[2]), "500000");
-    assert.equal(await erc20Guild.votingPowerOf(accounts[3]), "0");
-    assert.equal(await erc20Guild.votingPowerOf(accounts[4]), "0");
-    assert.equal(await erc20Guild.votingPowerOf(accounts[5]), "0");
+    assert.equal(await erc20Guild.getToken(), guildTokenA.address);
+    assert.equal(await erc20Guild.getTokenVault(), tokenVaultA);
 
-    assert.equal(await erc20Guild.getToken(), guildTokenB.address);
-    assert.equal(await erc20Guild.getTokenVault(), tokenVaultB.address);
-
-    await guildTokenB.approve(tokenVaultB.address, 500000, { from: accounts[3] });
-    await erc20Guild.lockTokens(500000, { from: accounts[3] });
-    assert.equal(await erc20Guild.votingPowerOf(accounts[3]), "500000");
   });
 
 });


### PR DESCRIPTION
Checks the bytecode of the new token vault to be used before executing the migration.