### PR TITLE
Fix DXD voting machine to reject transaction if value was sent from unregistered organization

### DIFF
--- a/contracts/dxvote/DXDVotingMachine.sol
+++ b/contracts/dxvote/DXDVotingMachine.sol
@@ -59,8 +59,11 @@ contract DXDVotingMachine is GenesisProtocol {
      * @dev Allows the voting machine to receive ether to be used to refund voting costs
      */
     function() external payable {
-        if (organizationRefunds[msg.sender].voteGas > 0)
-            organizationRefunds[msg.sender].balance = organizationRefunds[msg.sender].balance.add(msg.value);
+        require(
+            organizationRefunds[msg.sender].voteGas > 0, 
+            "DXDVotingMachine: Address not registered in organizationRefounds"
+        );
+        organizationRefunds[msg.sender].balance = organizationRefunds[msg.sender].balance.add(msg.value);
     }
 
     /**


### PR DESCRIPTION
Allow only registered organizations to send value to DXDVotingMachine. Avoid unregistered organizations in organizationRefounds mapping to send value.


Closes https://github.com/DXgovernance/dxdao-contracts/issues/69