### PR TITLE
feat/replaced mint with safemint and added tests

### DIFF
--- a/contracts/dxvote/utils/DXdaoNFT.sol
+++ b/contracts/dxvote/utils/DXdaoNFT.sol
@@ -10,13 +10,11 @@ contract DXdaoNFT is ERC721URIStorage, Ownable {
 
     constructor() ERC721("DXdao NFT", "DXNFT") {}
 
-    function mint(address recipient, string memory tokenURI) public onlyOwner returns (uint256) {
+    function mint(address recipient, string memory tokenURI) public onlyOwner {
         _tokenIds.increment();
 
         uint256 newItemId = _tokenIds.current();
-        _mint(recipient, newItemId);
+        _safeMint(recipient, newItemId);
         _setTokenURI(newItemId, tokenURI);
-
-        return newItemId;
     }
 }

--- a/test/dxvote/utils/DXdaoNFT.js
+++ b/test/dxvote/utils/DXdaoNFT.js
@@ -1,0 +1,31 @@
+import { artifacts, contract } from "hardhat";
+import { SOME_ADDRESS, SOME_TOKEN_URI } from "../../helpers/constants";
+import { expectRevert, expectEvent } from "@openzeppelin/test-helpers";
+
+const DXdaoNFT = artifacts.require("DXdaoNFT.sol");
+
+contract("DXdaoNFT", accounts => {
+  let dxDaoNFT;
+  beforeEach(async () => {
+    dxDaoNFT = await DXdaoNFT.new({
+      from: accounts[0],
+    });
+  });
+
+  describe.only("Mint DXdaoNFT", () => {
+    it("should mint a DXdaoNFT", async () => {
+      const mint = await dxDaoNFT.mint(SOME_ADDRESS, SOME_TOKEN_URI, {
+        from: accounts[0],
+      });
+      await expectEvent(mint, "Transfer");
+    });
+    it("should not mint a DXdaoNFT if not the owner", async () => {
+      await expectRevert(
+        dxDaoNFT.mint(SOME_ADDRESS, SOME_TOKEN_URI, {
+          from: accounts[1],
+        }),
+        "Ownable: caller is not the owner"
+      );
+    });
+  });
+});

--- a/test/dxvote/utils/DXdaoNFT.js
+++ b/test/dxvote/utils/DXdaoNFT.js
@@ -12,7 +12,7 @@ contract("DXdaoNFT", accounts => {
     });
   });
 
-  describe.only("Mint DXdaoNFT", () => {
+  describe("Mint DXdaoNFT", () => {
     it("should mint a DXdaoNFT", async () => {
       const mint = await dxDaoNFT.mint(SOME_ADDRESS, SOME_TOKEN_URI, {
         from: accounts[0],

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -15,6 +15,8 @@ export const ANY_FUNC_SIGNATURE = "0xaaaaaaaa";
 export const TEST_VALUE = 666;
 export const TEST_TITLE = "Awesome Proposal Title";
 export const ERC20_TRANSFER_SIGNATURE = "0xa9059cbb";
+export const SOME_TOKEN_URI =
+  "http://www.someTokenImplementation.com/tokens/19";
 
 export const WalletSchemeProposalState = {
   none: 0,


### PR DESCRIPTION
https://github.com/DXgovernance/dxdao-contracts/issues/82

- replaced `_mint`with `_safeMint`.
- Added test
- Removed `return` from the mint function since it does not return the `newItemId` but rather the mint receipt.