### PR TITLE
feat: Adding member count logic to snapshot implementation

### DIFF
--- a/contracts/erc20guild/implementations/SnapshotERC20Guild.sol
+++ b/contracts/erc20guild/implementations/SnapshotERC20Guild.sol
@@ -79,6 +79,7 @@ contract SnapshotERC20Guild is ERC20Guild {
     // @dev Lock tokens in the guild to be used as voting power
     // @param tokenAmount The amount of tokens to be locked
     function lockTokens(uint256 tokenAmount) external virtual override {
+        if (tokensLocked[msg.sender].amount == 0) totalMembers = totalMembers.add(1);
         _updateAccountSnapshot(msg.sender);
         _updateTotalSupplySnapshot();
         tokenVault.deposit(msg.sender, tokenAmount);
@@ -101,6 +102,7 @@ contract SnapshotERC20Guild is ERC20Guild {
         tokensLocked[msg.sender].amount = tokensLocked[msg.sender].amount.sub(tokenAmount);
         totalLocked = totalLocked.sub(tokenAmount);
         tokenVault.withdraw(msg.sender, tokenAmount);
+        if (tokensLocked[msg.sender].amount == 0) totalMembers = totalMembers.sub(1);
         emit TokensWithdrawn(msg.sender, tokenAmount);
     }
 

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1523,13 +1523,13 @@ contract("ERC20Guild", function (accounts) {
       // move past the time lock period
       await time.increase(TIMELOCK.add(new BN("1")));
 
-      // Can transfer because all user tokens are locked
+      // Cant transfer because all user tokens are locked
       await expectRevert(
         guildToken.transfer(accounts[0], 50, { from: accounts[1] }),
         "ERC20: transfer amount exceeds balance"
       );
 
-      // try to release more tha locked and fail
+      // try to release more than locked and fail
       await expectRevert(
         erc20Guild.withdrawTokens(50001, { from: accounts[1] }),
         "ERC20Guild: Unable to withdraw more tokens than locked"

--- a/test/erc20guild/implementations/SnapshotERC2Guild.js
+++ b/test/erc20guild/implementations/SnapshotERC2Guild.js
@@ -171,6 +171,7 @@ contract("SnapshotERC20Guild", function (accounts) {
         await erc20Guild.votingPowerOfAt(accounts[5], guildProposalIdSnapshot),
         "0"
       );
+      assert.equal(await erc20Guild.getTotalMembers(), 5);
 
       // Cant vote because it locked tokens after proposal
       await expectRevert(
@@ -197,6 +198,37 @@ contract("SnapshotERC20Guild", function (accounts) {
         proposalId: guildProposalId,
         newState: "3",
       });
+    });
+    it("Can withdraw tokens after time limit", async function () {
+      // move past the time lock period
+      await time.increase(new BN("60").add(new BN("1")));
+
+      // Cant transfer because all user tokens are locked
+      await expectRevert(
+        guildToken.transfer(accounts[0], 50, { from: accounts[1] }),
+        "ERC20: transfer amount exceeds balance"
+      );
+
+      // try to release more than locked and fail
+      await expectRevert(
+        erc20Guild.withdrawTokens(50001, { from: accounts[1] }),
+        "ERC20Guild: Unable to withdraw more tokens than locked"
+      );
+
+      const txRelease = await erc20Guild.withdrawTokens(50000, {
+        from: accounts[1],
+      });
+
+      const withdrawEvent = helpers.logDecoder.decodeLogs(
+        txRelease.receipt.rawLogs
+      )[1];
+      assert.equal(withdrawEvent.name, "TokensWithdrawn");
+      assert.equal(withdrawEvent.args[0], accounts[1]);
+      assert.equal(withdrawEvent.args[1], 50000);
+      assert.equal(await erc20Guild.getTotalMembers(), 1);
+
+      const votes = await erc20Guild.votingPowerOf(accounts[1]);
+      votes.should.be.bignumber.equal("0");
     });
   });
 });


### PR DESCRIPTION
Adding to snapshot lock and withdraw token implementation as currently it always stays at 1