### PR TITLE
Feature/add total member

### DIFF
--- a/contracts/test/ERC20SnapshotRepMock.sol
+++ b/contracts/test/ERC20SnapshotRepMock.sol
@@ -1,0 +1,30 @@
+pragma solidity 0.8.8;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "../utils/ERC20/ERC20SnapshotRep.sol";
+
+// mock class using ERC20SnapshotRep
+// @dev We want to expose the internal functions and test them
+contract ERC20SnapshotRepMock is ERC20SnapshotUpgradeable, ERC20SnapshotRep {
+    constructor() {}
+
+    function mint(address to, uint256 amount) public override {
+        _mint(to, amount);
+    }
+
+    function _addHolders(address account) public returns (bool) {
+        return addHolders(account);
+    }
+
+    function _removeHolders(address account) public returns (bool) {
+        return removeHolders(account);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual override(ERC20SnapshotRep, ERC20SnapshotUpgradeable) {
+        super._beforeTokenTransfer(from, to, amount);
+    }
+}

--- a/contracts/test/ERC20SnapshotRepMock.sol
+++ b/contracts/test/ERC20SnapshotRepMock.sol
@@ -8,23 +8,11 @@ import "../utils/ERC20/ERC20SnapshotRep.sol";
 contract ERC20SnapshotRepMock is ERC20SnapshotUpgradeable, ERC20SnapshotRep {
     constructor() {}
 
-    function mint(address to, uint256 amount) public override {
-        _mint(to, amount);
+    function _addHolder(address account) public returns (bool) {
+        return addHolder(account);
     }
 
-    function _addHolders(address account) public returns (bool) {
-        return addHolders(account);
-    }
-
-    function _removeHolders(address account) public returns (bool) {
-        return removeHolders(account);
-    }
-
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal virtual override(ERC20SnapshotRep, ERC20SnapshotUpgradeable) {
-        super._beforeTokenTransfer(from, to, amount);
+    function _removeHolder(address account) public returns (bool) {
+        return removeHolder(account);
     }
 }

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -4,11 +4,14 @@ pragma solidity ^0.8.8;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
 /**
  * @title ERC20SnapshotRep
  */
 contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+    using SafeMathUpgradeable for uint256;
+
     // @dev total holders of Rep tokens
     uint256 public totalHolders;
 
@@ -31,7 +34,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
 
     function addHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0) {
-            totalHolders++;
+            totalHolders = totalHolders.add(1);
             return true;
         } else {
             return false;
@@ -40,7 +43,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
 
     function removeHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0 && totalHolders > 0) {
-            totalHolders--;
+            totalHolders = totalHolders.sub(1);
             return true;
         } else {
             return false;

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -32,7 +32,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
         return totalHolders;
     }
 
-    function addHolders(address account) internal returns (bool) {
+    function addHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0) {
             totalHolders = totalHolders.add(1);
             return true;
@@ -41,7 +41,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
         }
     }
 
-    function removeHolders(address account) internal returns (bool) {
+    function removeHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0 && totalHolders > 0) {
             totalHolders = totalHolders.sub(1);
             return true;
@@ -53,7 +53,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
     function mint(address to, uint256 amount) external virtual onlyOwner {
         _snapshot();
         // @dev we only add to the totalHolders if they did not have tokens prior to minting
-        addHolders(to);
+        addHolder(to);
         _mint(to, amount);
     }
 
@@ -61,12 +61,6 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
         _snapshot();
         _burn(to, amount);
         // @dev we only remove from the totalHolders if they do not have tokens after burning
-        removeHolders(to);
+        removeHolder(to);
     }
-
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal virtual override onlyOwner {}
 }

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -51,16 +51,16 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
     }
 
     function mint(address to, uint256 amount) external virtual onlyOwner {
-        _snapshot();
         // @dev we only add to the totalHolders if they did not have tokens prior to minting
         addHolder(to);
         _mint(to, amount);
+        _snapshot();
     }
 
     function burn(address to, uint256 amount) external virtual onlyOwner {
-        _snapshot();
         _burn(to, amount);
         // @dev we only remove from the totalHolders if they do not have tokens after burning
         removeHolder(to);
+        _snapshot();
     }
 }

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -4,13 +4,11 @@ pragma solidity ^0.8.8;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
 /**
  * @title ERC20SnapshotRep
  */
 contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
-    using SafeMathUpgradeable for uint256;
 
     // @dev total holders of Rep tokens
     uint256 public totalHolders;
@@ -34,7 +32,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
 
     function addHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0) {
-            totalHolders = totalHolders.add(1);
+            totalHolders++;
             return true;
         } else {
             return false;
@@ -43,7 +41,7 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
 
     function removeHolder(address account) internal returns (bool) {
         if (balanceOf(account) == 0 && totalHolders > 0) {
-            totalHolders = totalHolders.sub(1);
+            totalHolders--;
             return true;
         } else {
             return false;

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -9,7 +9,6 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
  * @title ERC20SnapshotRep
  */
 contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
-
     // @dev total holders of Rep tokens
     uint256 public totalHolders;
 

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -4,11 +4,17 @@ pragma solidity ^0.8.8;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
 /**
  * @title ERC20SnapshotRep
  */
 contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+    using SafeMathUpgradeable for uint256;
+
+    // @dev total holders of Rep tokens
+    uint256 public totalHolders;
+
     function initialize(string memory name, string memory symbol) external initializer {
         __ERC20_init(name, symbol);
         __Ownable_init();
@@ -22,14 +28,40 @@ contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpg
         return _getCurrentSnapshotId();
     }
 
+    function getTotalHolders() external view returns (uint256) {
+        return totalHolders;
+    }
+
+    function addHolders(address account) internal returns (bool) {
+        if (balanceOf(account) == 0) {
+            totalHolders = totalHolders.add(1);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function removeHolders(address account) internal returns (bool) {
+        if (balanceOf(account) == 0 && totalHolders > 0) {
+            totalHolders = totalHolders.sub(1);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     function mint(address to, uint256 amount) external virtual onlyOwner {
         _snapshot();
+        // @dev we only add to the totalHolders if they did not have tokens prior to minting
+        addHolders(to);
         _mint(to, amount);
     }
 
     function burn(address to, uint256 amount) external virtual onlyOwner {
         _snapshot();
         _burn(to, amount);
+        // @dev we only remove from the totalHolders if they do not have tokens after burning
+        removeHolders(to);
     }
 
     function _beforeTokenTransfer(

--- a/package.json
+++ b/package.json
@@ -101,8 +101,7 @@
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,md,sol}": [
       "yarn format",
-      "yarn solidity-linter",
-      "git add"
+      "yarn solidity-linter"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "*.{ts,tsx,js,jsx,json,md,sol}": [
       "yarn format",
       "yarn solidity-linter",
-      "git add"
+      "git add",
+      "yarn test"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,8 +102,7 @@
     "*.{ts,tsx,js,jsx,json,md,sol}": [
       "yarn format",
       "yarn solidity-linter",
-      "git add",
-      "yarn test"
+      "git add"
     ]
   }
 }

--- a/test/utils/ERC20/ERC20SnapshotRep.js
+++ b/test/utils/ERC20/ERC20SnapshotRep.js
@@ -1,0 +1,57 @@
+import { assert } from "chai";
+import { artifacts, contract } from "hardhat";
+import { SOME_ADDRESS } from "../../helpers/constants";
+
+const ERC20SnapshotRepMock = artifacts.require(
+  "./test/ERC20SnapshotRepMock.sol"
+);
+
+contract("ERC20SnapshotRep", accounts => {
+  let ERC20SnapshotRep;
+
+  beforeEach(async () => {
+    ERC20SnapshotRep = await ERC20SnapshotRepMock.new({
+      from: accounts[0],
+    });
+    await ERC20SnapshotRep.initialize("DXdao", "DXD");
+    await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+  });
+
+  describe("Add and remove totalHolders", () => {
+    it("should return one totalHolder", async () => {
+      const totalHolders = await ERC20SnapshotRep.getTotalHolders();
+      assert.equal(totalHolders, 1);
+    });
+
+    it("should add totalHolders", async () => {
+      await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+      const totalHolders = await ERC20SnapshotRep.getTotalHolders();
+      assert.equal(totalHolders, 2);
+    });
+    it("should subtract totalHolders", async () => {
+      await ERC20SnapshotRep._removeHolders(SOME_ADDRESS, {
+        from: accounts[0],
+      });
+      const totalHolders = await ERC20SnapshotRep.getTotalHolders();
+      assert.equal(totalHolders, 0);
+    });
+
+    it("should not add totalHolders if address has balance", async () => {
+      await ERC20SnapshotRep.mint(SOME_ADDRESS, 100, {
+        from: accounts[0],
+      });
+      await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+      const totalHolders = await ERC20SnapshotRep.getTotalHolders();
+      assert.equal(totalHolders, 1);
+    });
+  });
+
+  it("should not subtract totalHolders if address has balance", async () => {
+    await ERC20SnapshotRep.mint(SOME_ADDRESS, 100, {
+      from: accounts[0],
+    });
+    await ERC20SnapshotRep._removeHolders(SOME_ADDRESS, { from: accounts[0] });
+    const totalHolders = await ERC20SnapshotRep.getTotalHolders();
+    assert.equal(totalHolders, 1);
+  });
+});

--- a/test/utils/ERC20/ERC20SnapshotRep.js
+++ b/test/utils/ERC20/ERC20SnapshotRep.js
@@ -14,7 +14,7 @@ contract("ERC20SnapshotRep", accounts => {
       from: accounts[0],
     });
     await ERC20SnapshotRep.initialize("DXdao", "DXD");
-    await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+    await ERC20SnapshotRep._addHolder(SOME_ADDRESS, { from: accounts[0] });
   });
 
   describe("Add and remove totalHolders", () => {
@@ -24,12 +24,12 @@ contract("ERC20SnapshotRep", accounts => {
     });
 
     it("should add totalHolders", async () => {
-      await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+      await ERC20SnapshotRep._addHolder(SOME_ADDRESS, { from: accounts[0] });
       const totalHolders = await ERC20SnapshotRep.getTotalHolders();
       assert.equal(totalHolders, 2);
     });
     it("should subtract totalHolders", async () => {
-      await ERC20SnapshotRep._removeHolders(SOME_ADDRESS, {
+      await ERC20SnapshotRep._removeHolder(SOME_ADDRESS, {
         from: accounts[0],
       });
       const totalHolders = await ERC20SnapshotRep.getTotalHolders();
@@ -40,9 +40,9 @@ contract("ERC20SnapshotRep", accounts => {
       await ERC20SnapshotRep.mint(SOME_ADDRESS, 100, {
         from: accounts[0],
       });
-      await ERC20SnapshotRep._addHolders(SOME_ADDRESS, { from: accounts[0] });
+      await ERC20SnapshotRep.mint(SOME_ADDRESS, 100, { from: accounts[0] });
       const totalHolders = await ERC20SnapshotRep.getTotalHolders();
-      assert.equal(totalHolders, 1);
+      assert.equal(totalHolders, 2);
     });
   });
 
@@ -50,8 +50,8 @@ contract("ERC20SnapshotRep", accounts => {
     await ERC20SnapshotRep.mint(SOME_ADDRESS, 100, {
       from: accounts[0],
     });
-    await ERC20SnapshotRep._removeHolders(SOME_ADDRESS, { from: accounts[0] });
+    await ERC20SnapshotRep.burn(SOME_ADDRESS, 50, { from: accounts[0] });
     const totalHolders = await ERC20SnapshotRep.getTotalHolders();
-    assert.equal(totalHolders, 1);
+    assert.equal(totalHolders, 2);
   });
 });


### PR DESCRIPTION
Issue: https://github.com/DXgovernance/dxdao-contracts/issues/129

- Added a `totalHolder` count for our `ERC20SnapshotRep.sol` contract
- Added a mock for testing `internal` functions and simplifying `mint` functions
- Added tests

Was trying to figure out how to test internal functions and simplify minting. The best practice seemed to just make an inheritance contract overriding functions and exposing internal functions. Let me know if this is the way we should do it, and if there are eventual other issues with this approach.