### PR TITLE
Fix/create proposal with zero totallocked

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -103,6 +103,9 @@ contract BaseERC20Guild {
     // The total amount of tokens locked
     uint256 public totalLocked;
 
+    // The number of minimum guild members to be able to create a proposal
+    uint256 public minimumMembersForProposalCreation;
+
     // The address of the Token Vault contract, where tokens are being held for the users
     TokenVault public tokenVault;
 
@@ -172,7 +175,9 @@ contract BaseERC20Guild {
         uint256 _voteGas,
         uint256 _maxGasPrice,
         uint256 _maxActiveProposals,
-        uint256 _lockTime
+        uint256 _lockTime,
+        uint256 _minimumMembersForProposalCreation
+        
     ) external virtual {
         require(msg.sender == address(this), "ERC20Guild: Only callable by ERC20guild itself when initialized");
         require(_proposalTime > 0, "ERC20Guild: proposal time has to be more tha 0");
@@ -186,6 +191,7 @@ contract BaseERC20Guild {
         maxGasPrice = _maxGasPrice;
         maxActiveProposals = _maxActiveProposals;
         lockTime = _lockTime;
+        minimumMembersForProposalCreation = _minimumMembersForProposalCreation;
     }
 
     // @dev Set the allowance of a call to be executed by the guild
@@ -225,7 +231,7 @@ contract BaseERC20Guild {
                 address(0),
                 address(this),
                 address(this),
-                bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"))
+                bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"))
             ) > 0,
             "ERC20Guild: setConfig function allowance cant be turned off"
         );
@@ -271,6 +277,10 @@ contract BaseERC20Guild {
         string memory title,
         string memory contentHash
     ) public virtual returns (bytes32) {
+        require(
+            totalMembers >= minimumMembersForProposalCreation, 
+            'ERC20Guild: Not enough members to create a proposal'
+        );
         require(activeProposalsNow < getMaxActiveProposals(), "ERC20Guild: Maximum amount of active proposals reached");
         require(
             votingPowerOf(msg.sender) >= getVotingPowerForProposalCreation(),

--- a/contracts/erc20guild/ERC20Guild.sol
+++ b/contracts/erc20guild/ERC20Guild.sol
@@ -45,7 +45,9 @@ contract ERC20Guild is BaseERC20Guild {
             address(0),
             address(this),
             address(this),
-            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
+            bytes4(
+                keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")
+            ),
             0,
             true
         );
@@ -72,5 +74,7 @@ contract ERC20Guild is BaseERC20Guild {
         voteGas = 0;
         maxGasPrice = 0;
         maxActiveProposals = 5;
+        minimumMembersForProposalCreation = 0;
+        minimumTokensLockedForProposalCreation = 0;
     }
 }

--- a/contracts/erc20guild/ERC20Guild.sol
+++ b/contracts/erc20guild/ERC20Guild.sol
@@ -45,7 +45,7 @@ contract ERC20Guild is BaseERC20Guild {
             address(0),
             address(this),
             address(this),
-            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
+            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
             0,
             true
         );

--- a/contracts/erc20guild/ERC20Guild.sol
+++ b/contracts/erc20guild/ERC20Guild.sol
@@ -74,7 +74,5 @@ contract ERC20Guild is BaseERC20Guild {
         voteGas = 0;
         maxGasPrice = 0;
         maxActiveProposals = 5;
-        minimumMembersForProposalCreation = 0;
-        minimumTokensLockedForProposalCreation = 0;
     }
 }

--- a/contracts/erc20guild/ERC20GuildUpgradeable.sol
+++ b/contracts/erc20guild/ERC20GuildUpgradeable.sol
@@ -80,7 +80,9 @@ contract ERC20GuildUpgradeable is BaseERC20Guild, Initializable {
             address(0),
             address(this),
             address(this),
-            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
+            bytes4(
+                keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")
+            ),
             0,
             true
         );
@@ -100,5 +102,9 @@ contract ERC20GuildUpgradeable is BaseERC20Guild, Initializable {
             0,
             true
         );
+
+        // Set default values for baseERC20Guild
+        minimumMembersForProposalCreation = 0;
+        minimumTokensLockedForProposalCreation = 0;
     }
 }

--- a/contracts/erc20guild/ERC20GuildUpgradeable.sol
+++ b/contracts/erc20guild/ERC20GuildUpgradeable.sol
@@ -102,9 +102,5 @@ contract ERC20GuildUpgradeable is BaseERC20Guild, Initializable {
             0,
             true
         );
-
-        // Set default values for baseERC20Guild
-        minimumMembersForProposalCreation = 0;
-        minimumTokensLockedForProposalCreation = 0;
     }
 }

--- a/contracts/erc20guild/ERC20GuildUpgradeable.sol
+++ b/contracts/erc20guild/ERC20GuildUpgradeable.sol
@@ -80,7 +80,7 @@ contract ERC20GuildUpgradeable is BaseERC20Guild, Initializable {
             address(0),
             address(this),
             address(this),
-            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
+            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
             0,
             true
         );

--- a/contracts/erc20guild/IERC20Guild.sol
+++ b/contracts/erc20guild/IERC20Guild.sol
@@ -141,6 +141,10 @@ interface IERC20Guild {
 
     function getActiveProposalsNow() external view returns (uint256);
 
+    function getMinimumMembersForProposalCreation() external view returns (uint256);
+
+    function getMinimumTokensLockedForProposalCreation() external view returns (uint256);
+
     function getSignedVote(bytes32 signedVoteHash) external view returns (bool);
 
     function getProposalsIds() external view returns (bytes32[] memory);

--- a/contracts/erc20guild/implementations/ERC20GuildWithERC1271.sol
+++ b/contracts/erc20guild/implementations/ERC20GuildWithERC1271.sol
@@ -9,8 +9,8 @@ import "../ERC20GuildUpgradeable.sol";
 /*
   @title ERC20GuildWithERC1271
   @author github:AugustoL
-  @dev The guild can sign EIP1271 messages, to do this the guild needs to call itself 
-    and allow the signature to be verified with and extra signature of any account with voting power.
+  @dev The guild can sign EIP1271 messages, to do this the guild needs to call itself and allow 
+    the signature to be verified with and extra signature of any account with voting power.
 */
 contract ERC20GuildWithERC1271 is ERC20GuildUpgradeable, IERC1271Upgradeable {
     using SafeMathUpgradeable for uint256;
@@ -72,7 +72,9 @@ contract ERC20GuildWithERC1271 is ERC20GuildUpgradeable, IERC1271Upgradeable {
             address(0),
             address(this),
             address(this),
-            bytes4(keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")),
+            bytes4(
+                keccak256("setConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")
+            ),
             0,
             true
         );

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1609,7 +1609,9 @@ contract("ERC20Guild", function (accounts) {
       );
 
       const timestampAfterOriginalTimeLock = await time.latest();
-      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(timestampAfterOriginalTimeLock);
+      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(
+        timestampAfterOriginalTimeLock
+      );
       await time.increase(timeTillVoteTimeLock);
       const txRelease = await erc20Guild.withdrawTokens(50000, {
         from: accounts[3],

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -211,6 +211,11 @@ contract("ERC20Guild", function (accounts) {
       assert.equal(await erc20Guild.getProposalsIdsLength(), 0);
       assert.equal(await erc20Guild.getTotalMembers(), 0);
       assert.deepEqual(await erc20Guild.getProposalsIds(), []);
+      assert.equal(await erc20Guild.getMinimumMembersForProposalCreation(), 0);
+      assert.equal(
+        await erc20Guild.getMinimumTokensLockedForProposalCreation(),
+        0
+      );
     });
 
     it("cannot initialize with zero token", async function () {


### PR DESCRIPTION
- Modify BaseERC20 setConfig function to accept new `minimumMembersForProposalCreation` and `minimumTokensLockedForProposalCreation`
- Add minimum members validation before create proposal
- Add minimum tokensLocked validation before create proposal
- Include tests and fix previous setConfig signatures

Closes https://github.com/DXgovernance/dxdao-contracts/issues/158