### PR TITLE
Fix/gas refund on set vote

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -161,7 +161,7 @@ contract BaseERC20Guild {
     // @param _votingPowerForProposalExecution The percentage of voting power in base 10000 needed to execute a proposal
     // action
     // @param _votingPowerForProposalCreation The percentage of voting power in base 10000 needed to create a proposal
-    // @param _voteGas The amount of gas in wei unit used for vote refunds. Can't be higher than 85% of the gas used by setVote (100000)
+    // @param _voteGas The amount of gas in wei unit used for vote refunds. Can't be higher than the gas used by setVote (117000)
     // @param _maxGasPrice The maximum gas price used for vote refunds
     // @param _maxActiveProposals The maximum amount of proposals to be active at the same time
     // @param _lockTime The minimum amount of seconds that the tokens would be locked
@@ -179,7 +179,7 @@ contract BaseERC20Guild {
         require(_proposalTime > 0, "ERC20Guild: proposal time has to be more than 0");
         require(_lockTime >= _proposalTime, "ERC20Guild: lockTime has to be higher or equal to proposalTime");
         require(_votingPowerForProposalExecution > 0, "ERC20Guild: voting power for execution has to be more than 0");
-        require(_voteGas <= 100000, "ERC20Guild: vote gas has to be equal or lower than 100.000"); // 100.000 is 85% of the gas amount to execute setVote
+        require(_voteGas <= 117000, "ERC20Guild: vote gas has to be equal or lower than 117.000");
         proposalTime = _proposalTime;
         timeForExecution = _timeForExecution;
         votingPowerForProposalExecution = _votingPowerForProposalExecution;

--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -179,7 +179,7 @@ contract BaseERC20Guild {
         require(_proposalTime > 0, "ERC20Guild: proposal time has to be more than 0");
         require(_lockTime >= _proposalTime, "ERC20Guild: lockTime has to be higher or equal to proposalTime");
         require(_votingPowerForProposalExecution > 0, "ERC20Guild: voting power for execution has to be more than 0");
-        require(_voteGas <= 117000, "ERC20Guild: vote gas has to be equal or lower than 117.000");
+        require(_voteGas <= 117000, "ERC20Guild: vote gas has to be equal or lower than 117000");
         proposalTime = _proposalTime;
         timeForExecution = _timeForExecution;
         votingPowerForProposalExecution = _votingPowerForProposalExecution;

--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -161,7 +161,7 @@ contract BaseERC20Guild {
     // @param _votingPowerForProposalExecution The percentage of voting power in base 10000 needed to execute a proposal
     // action
     // @param _votingPowerForProposalCreation The percentage of voting power in base 10000 needed to create a proposal
-    // @param _voteGas The amount of gas in wei unit used for vote refunds
+    // @param _voteGas The amount of gas in wei unit used for vote refunds. Can't be higher than 85% of the gas used by setVote (100000)
     // @param _maxGasPrice The maximum gas price used for vote refunds
     // @param _maxActiveProposals The maximum amount of proposals to be active at the same time
     // @param _lockTime The minimum amount of seconds that the tokens would be locked
@@ -176,9 +176,10 @@ contract BaseERC20Guild {
         uint256 _lockTime
     ) external virtual {
         require(msg.sender == address(this), "ERC20Guild: Only callable by ERC20guild itself when initialized");
-        require(_proposalTime > 0, "ERC20Guild: proposal time has to be more tha 0");
+        require(_proposalTime > 0, "ERC20Guild: proposal time has to be more than 0");
         require(_lockTime >= _proposalTime, "ERC20Guild: lockTime has to be higher or equal to proposalTime");
         require(_votingPowerForProposalExecution > 0, "ERC20Guild: voting power for execution has to be more than 0");
+        require(_voteGas <= 100000, "ERC20Guild: vote gas has to be equal or lower than 100.000"); // 100.000 is 85% of the gas amount to execute setVote
         proposalTime = _proposalTime;
         timeForExecution = _timeForExecution;
         votingPowerForProposalExecution = _votingPowerForProposalExecution;
@@ -478,10 +479,7 @@ contract BaseERC20Guild {
         emit VoteAdded(proposalId, action, voter, votingPower);
 
         if (voteGas > 0) {
-            // Set upper limit on amount of gas refund based on the amount of gas used
-            // 100.000 ~= 85% * 117.760 (gas used)
-            uint256 amountOfGasRefunded = voteGas.min(100000);
-            uint256 gasRefund = amountOfGasRefunded.mul(tx.gasprice.min(maxGasPrice));
+            uint256 gasRefund = voteGas.mul(tx.gasprice.min(maxGasPrice));
 
             if (address(this).balance >= gasRefund && !address(msg.sender).isContract()) {
                 (bool success, ) = payable(msg.sender).call{value: gasRefund}("");

--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -478,7 +478,11 @@ contract BaseERC20Guild {
         emit VoteAdded(proposalId, action, voter, votingPower);
 
         if (voteGas > 0) {
-            uint256 gasRefund = voteGas.mul(tx.gasprice.min(maxGasPrice));
+            // Set upper limit on amount of gas refund based on the amount of gas used
+            // 100.000 ~= 85% * 117.760 (gas used)
+            uint256 amountOfGasRefunded = voteGas.min(100000);
+            uint256 gasRefund = amountOfGasRefunded.mul(tx.gasprice.min(maxGasPrice));
+
             if (address(this).balance >= gasRefund && !address(msg.sender).isContract()) {
                 (bool success, ) = payable(msg.sender).call{value: gasRefund}("");
                 require(success, "Failed to refund gas");

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1374,7 +1374,7 @@ contract("ERC20Guild", function (accounts) {
     });
 
     describe("with high gas vote setting (above cost) and standard gas price", function () {
-      it("can pay ETH to the guild (ot cover votes)", async function () {
+      it("can pay ETH to the guild (to cover votes)", async function () {
         const tracker = await balance.tracker(erc20Guild.address);
         let guildBalance = await tracker.delta();
         guildBalance.should.be.bignumber.equal(ZERO); // empty
@@ -1473,9 +1473,154 @@ contract("ERC20Guild", function (accounts) {
           );
         }
       });
+
+      it.only("cannot empty contract if voteGas is incorrectly set", async function () {
+        let incorrectVoteGas = new BN(220000);
+        const guildProposalIncorrectVoteGas = await createProposal({
+          guild: erc20Guild,
+          actions: [
+            {
+              to: [erc20Guild.address],
+              data: [
+                await new web3.eth.Contract(ERC20Guild.abi).methods
+                  .setConfig(
+                    30,
+                    30,
+                    200,
+                    100,
+                    incorrectVoteGas,
+                    REAL_GAS_PRICE,
+                    3,
+                    60
+                  )
+                  .encodeABI(),
+              ],
+              value: [0],
+            },
+          ],
+          account: accounts[3],
+        });
+        await setVotesOnProposal({
+          guild: erc20Guild,
+          proposalId: guildProposalIncorrectVoteGas,
+          action: 1,
+          account: accounts[4],
+        });
+        await setVotesOnProposal({
+          guild: erc20Guild,
+          proposalId: guildProposalIncorrectVoteGas,
+          action: 1,
+          account: accounts[5],
+        });
+        await time.increase(time.duration.seconds(31));
+        await erc20Guild.endProposal(guildProposalIncorrectVoteGas);
+
+        (await erc20Guild.getVoteGas()).should.be.bignumber.equal(
+          incorrectVoteGas
+        );
+
+        // send ether to cover gas
+        await send.ether(accounts[0], erc20Guild.address, ether("10"), {
+          from: accounts[0],
+        });
+
+        const newProposal = await createProposal(genericProposal);
+        const accountBalanceTracker = await balance.tracker(accounts[1]);
+
+        let txVote = await setVotesOnProposal({
+          guild: erc20Guild,
+          proposalId: newProposal,
+          action: 1,
+          account: accounts[1],
+        });
+
+        console.log(txVote.receipt);
+
+        let accountBalance = await accountBalanceTracker.delta();
+        accountBalance.negative.should.be.equal(1); // The variation in balance is negative
+      });
+
+      it.only("a user cannot modify maxGasPrice to exploit it", async function () {
+        // send ether to cover gas
+        await send.ether(accounts[0], erc20Guild.address, ether("10"), {
+          from: accounts[0],
+        });
+
+        await time.increase(time.duration.seconds(31));
+        await erc20Guild.withdrawTokens(50000, { from: accounts[2] });
+        await erc20Guild.withdrawTokens(100000, { from: accounts[3] });
+        await erc20Guild.withdrawTokens(100000, { from: accounts[4] });
+        await erc20Guild.withdrawTokens(200000, { from: accounts[5] });
+
+        let highMaxGasPrice = new BN(20000000000000); // 20.000 gwei
+        const proposalWithHighMaxGasPrice = await createProposal({
+          guild: erc20Guild,
+          actions: [
+            {
+              to: [erc20Guild.address],
+              data: [
+                await new web3.eth.Contract(ERC20Guild.abi).methods
+                  .setConfig(30, 30, 200, 100, VOTE_GAS, highMaxGasPrice, 3, 60)
+                  .encodeABI(),
+              ],
+              value: [0],
+            },
+          ],
+          account: accounts[1],
+        });
+        await setVotesOnProposal({
+          guild: erc20Guild,
+          proposalId: proposalWithHighMaxGasPrice,
+          action: 1,
+          account: accounts[1],
+        });
+        await time.increase(time.duration.seconds(31));
+        await erc20Guild.endProposal(proposalWithHighMaxGasPrice);
+
+        const txGasPriceExploitProposal = await createProposal({
+          guild: erc20Guild,
+          actions: [
+            {
+              to: [accounts[1]],
+              data: [helpers.testCallFrom(erc20Guild.address)],
+              value: [1],
+            },
+          ],
+          account: accounts[1],
+        });
+
+        const accountBalanceTracker = await balance.tracker(accounts[1]);
+        let exploitVote = await erc20Guild.setVote(
+          txGasPriceExploitProposal,
+          1,
+          100,
+          {
+            from: accounts[1],
+            gasPrice: highMaxGasPrice,
+          }
+        );
+
+        let actualGasPaid = web3.utils.hexToNumber(
+          exploitVote.receipt.effectiveGasPrice
+        );
+        let totalSpent = exploitVote.receipt.gasUsed * actualGasPaid;
+        console.log(
+          "",
+          web3.utils.fromWei(totalSpent.toString(), "ether"),
+          " eth cost of the transaction"
+        );
+
+        let accountBalance = await accountBalanceTracker.delta();
+        const etherValue = web3.utils.fromWei(
+          accountBalance.toString(),
+          "ether"
+        );
+
+        console.log(await etherValue, " eth lost on the wallet");
+      });
     });
 
-    it("only refunds upto max gas price", async function () {
+    it("only refunds up to max gas price", async function () {
       const guildProposalId = await createProposal(genericProposal);
 
       const guildTracker = await balance.tracker(erc20Guild.address);

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1404,7 +1404,9 @@ contract("ERC20Guild", function (accounts) {
       );
 
       const timestampAfterOriginalTimeLock = await time.latest();
-      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(timestampAfterOriginalTimeLock);
+      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(
+        timestampAfterOriginalTimeLock
+      );
       await time.increase(timeTillVoteTimeLock);
       const txRelease = await erc20Guild.withdrawTokens(50000, {
         from: accounts[3],


### PR DESCRIPTION
Relates to issue #159, and DXD-11 in the audit.

Fixes `setVote` exploit when `voteGas` amount is set above the actual gas spent for the function call, enabling voters to get refunded more than what they spent to call the function.

It sets a hard limit of 100.000 gas (~85% of the actual 117.000 gas needed to execute `setVote()`).