### PR TITLE
Fix/early withdrawal manipulation

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -134,6 +134,7 @@ contract BaseERC20Guild {
         string contentHash;
         ProposalState state;
         uint256[] totalVotes;
+        uint256 votingPowerForProposalExecution;
     }
 
     // Mapping of proposal votes
@@ -298,6 +299,7 @@ contract BaseERC20Guild {
         newProposal.contentHash = contentHash;
         newProposal.totalVotes = new uint256[](totalActions.add(1));
         newProposal.state = ProposalState.Active;
+        newProposal.votingPowerForProposalExecution = getVotingPowerForProposalExecution();
 
         activeProposalsNow = activeProposalsNow.add(1);
         emit ProposalStateChanged(proposalId, uint256(ProposalState.Active));
@@ -315,7 +317,7 @@ contract BaseERC20Guild {
         uint256 i = 1;
         for (i = 1; i < proposals[proposalId].totalVotes.length; i++) {
             if (
-                proposals[proposalId].totalVotes[i] >= getVotingPowerForProposalExecution() &&
+                proposals[proposalId].totalVotes[i] >= proposals[proposalId].votingPowerForProposalExecution &&
                 proposals[proposalId].totalVotes[i] > proposals[proposalId].totalVotes[winningAction]
             ) winningAction = i;
         }


### PR DESCRIPTION
Relates to issue #167, and DXD-19 in the audit.

Users were allowed to decrease voting power for proposal execution by withdrawing their tokens after voting.

Added a new variable to `Proposal` struct: votingPowerForProposalExecution.

Now, the voting power is calculated at the time of proposal creation and stored. Then, when executing the proposal, voting power is read from the Proposal instead of calculated on the fly.