### PR TITLE
Bugfix/double voting bug

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -475,6 +475,11 @@ contract BaseERC20Guild {
         proposalVotes[proposalId][voter].action = action;
         proposalVotes[proposalId][voter].votingPower = votingPower;
 
+        // Make sure tokens don't get unlocked before the proposal ends, to prevent double voting.
+        if (tokensLocked[voter].timestamp < proposals[proposalId].endTime) {
+            tokensLocked[voter].timestamp = proposals[proposalId].endTime;
+        }
+
         emit VoteAdded(proposalId, action, voter, votingPower);
 
         if (voteGas > 0) {

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1333,6 +1333,91 @@ contract("ERC20Guild", function (accounts) {
     });
 
     it("can lock tokens and check snapshot", async function () {});
+
+    it("increases lock time to at least proposal end time after voting", async function () {
+      const tokenVault = await erc20Guild.getTokenVault();
+      const TIMELOCK = new BN("60");
+
+      // approve lockable guild to "transfer in" tokens to lock
+      await guildToken.approve(tokenVault, 50000, { from: accounts[3] });
+      assert.equal(await erc20Guild.getTotalMembers(), 0);
+
+      // Lock tokens
+      const txLock = await erc20Guild.lockTokens(50000, { from: accounts[3] });
+      const lockEvent = helpers.logDecoder.decodeLogs(
+        txLock.receipt.rawLogs
+      )[2];
+      assert.equal(lockEvent.name, "TokensLocked");
+      assert.equal(lockEvent.args[0], accounts[3]);
+      assert.equal(lockEvent.args[1], 50000);
+      assert.equal(await erc20Guild.getTotalMembers(), 1);
+
+      // Ensure tokens have been locked
+      const timestampOnLock = await time.latest();
+      let voterLockTimestampAtLockTime = await erc20Guild.getVoterLockTimestamp(
+        accounts[3]
+      );
+      voterLockTimestampAtLockTime.should.be.bignumber.equal(
+        timestampOnLock.add(TIMELOCK)
+      );
+
+      // Increase time
+      const proposalDelay = new BN("40");
+      await time.increase(proposalDelay);
+
+      // Create a new proposal and vote on it
+      const guildProposalId = await createProposal(genericProposal);
+      const { endTime: proposalEndTime } = await erc20Guild.getProposal(
+        guildProposalId
+      );
+
+      await setVotesOnProposal({
+        guild: erc20Guild,
+        proposalId: guildProposalId,
+        action: 3,
+        account: accounts[3],
+      });
+
+      // Ensure tokens lock has been extended
+      let voterLockTimestampAfterVote = await erc20Guild.getVoterLockTimestamp(
+        accounts[3]
+      );
+      voterLockTimestampAfterVote.should.not.be.bignumber.equal(
+        voterLockTimestampAtLockTime
+      );
+      voterLockTimestampAfterVote.should.be.bignumber.equal(proposalEndTime);
+
+      // try lo release and fail
+      await expectRevert(
+        erc20Guild.withdrawTokens(1, { from: accounts[3] }),
+        "ERC20Guild: Tokens still locked"
+      );
+      const timestampAfterVote = await time.latest();
+
+      // move past the original time lock period and try to redeem and fail
+      const timeTillOriginalTimeLock =
+        voterLockTimestampAtLockTime.sub(timestampAfterVote);
+      await time.increase(timeTillOriginalTimeLock);
+      await expectRevert(
+        erc20Guild.withdrawTokens(1, { from: accounts[3] }),
+        "ERC20Guild: Tokens still locked"
+      );
+
+      const timestampAfterOriginalTimeLock = await time.latest();
+      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(timestampAfterOriginalTimeLock);
+      await time.increase(timeTillVoteTimeLock);
+      const txRelease = await erc20Guild.withdrawTokens(50000, {
+        from: accounts[3],
+      });
+      assert.equal(await erc20Guild.getTotalMembers(), 0);
+
+      const withdrawEvent = helpers.logDecoder.decodeLogs(
+        txRelease.receipt.rawLogs
+      )[1];
+      assert.equal(withdrawEvent.name, "TokensWithdrawn");
+      assert.equal(withdrawEvent.args[0], accounts[3]);
+      assert.equal(withdrawEvent.args[1], 50000);
+    });
   });
   describe("refund votes", function () {
     beforeEach(async function () {


### PR DESCRIPTION
Fixes #150 - DXD-02: Double-voting in `BaseERC20Guild`.

Previous behavior:
After locking tokens and voting on a proposal, a user could withdraw their tokens when their locking period ends, even if the voting hasn't finished. This way, it was possible for the tokens to be moved to a different wallet and used for voting again.

New behavior:
Whenever a user votes on a proposal, their token lock-time is extended to at least the end time of the voted proposal, preventing the attack.

Modified `BaseERC20Guild.sol` and added tests.