### PR TITLE
fix: change from transfer to call value

### DIFF
--- a/contracts/daostack/controller/Avatar.sol
+++ b/contracts/daostack/controller/Avatar.sol
@@ -70,9 +70,10 @@ contract Avatar is Ownable {
      * @return bool which represents success
      */
     function sendEther(uint256 _amountInWei, address payable _to) public onlyOwner returns (bool) {
-        _to.call.value(_amountInWei)("");
+        (bool sent, bytes memory data) = _to.call.value(_amountInWei)("");
+        require(sent, "Failed to send ethers");
         emit SendEther(_amountInWei, _to);
-        return true;
+        return sent;
     }
 
     /**

--- a/contracts/daostack/controller/Avatar.sol
+++ b/contracts/daostack/controller/Avatar.sol
@@ -71,7 +71,7 @@ contract Avatar is Ownable {
      */
     function sendEther(uint256 _amountInWei, address payable _to) public onlyOwner returns (bool) {
         (bool sent, bytes memory data) = _to.call.value(_amountInWei)("");
-        require(sent, "Failed to send ethers");
+        require(sent, "eth transfer failed");
         emit SendEther(_amountInWei, _to);
         return sent;
     }

--- a/contracts/daostack/controller/Avatar.sol
+++ b/contracts/daostack/controller/Avatar.sol
@@ -70,7 +70,7 @@ contract Avatar is Ownable {
      * @return bool which represents success
      */
     function sendEther(uint256 _amountInWei, address payable _to) public onlyOwner returns (bool) {
-        _to.transfer(_amountInWei);
+        _to.call.value(_amountInWei)("");
         emit SendEther(_amountInWei, _to);
         return true;
     }

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1404,7 +1404,9 @@ contract("ERC20Guild", function (accounts) {
       );
 
       const timestampAfterOriginalTimeLock = await time.latest();
-      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(timestampAfterOriginalTimeLock);
+      const timeTillVoteTimeLock = voterLockTimestampAfterVote.sub(
+        timestampAfterOriginalTimeLock
+      );
       await time.increase(timeTillVoteTimeLock);
       const txRelease = await erc20Guild.withdrawTokens(50000, {
         from: accounts[3],


### PR DESCRIPTION
Issue: https://github.com/DXgovernance/dxdao-contracts/issues/84

Change from `transfer` to `.call.value`