### PR TITLE
Fix deploy file

### DIFF
--- a/scripts/deploymentTemplates/guilds-goerli.js
+++ b/scripts/deploymentTemplates/guilds-goerli.js
@@ -125,7 +125,7 @@ task(
     guilds: [
       {
         token: "SWPR",
-        contractName: "EnforcedBinarySnapshotERC20Guild",
+        contractName: "ERC20GuildUpgradeable",
         name: "SWPRGuild",
         proposalTime: moment.duration(10, "minutes").asSeconds(),
         timeForExecution: moment.duration(5, "minutes").asSeconds(),

--- a/scripts/deploymentTemplates/guilds-goerli.js
+++ b/scripts/deploymentTemplates/guilds-goerli.js
@@ -125,7 +125,7 @@ task(
     guilds: [
       {
         token: "SWPR",
-        contractName: "ERC20GuildUpgradeable",
+        contractName: "SnapshotERC20Guild",
         name: "SWPRGuild",
         proposalTime: moment.duration(10, "minutes").asSeconds(),
         timeForExecution: moment.duration(5, "minutes").asSeconds(),


### PR DESCRIPTION
Remove EnforcedBinarySnapshotERC20Guild from goerli deploy file. 

Dapp fix part (dev script): https://github.com/DXgovernance/DAVI/pull/81
Closes https://github.com/DXgovernance/dxdao-contracts/issues/193
