### PR TITLE
fix: update internal state before external call

### DIFF
--- a/contracts/dxvote/DXDVotingMachine.sol
+++ b/contracts/dxvote/DXDVotingMachine.sol
@@ -94,8 +94,9 @@ contract DXDVotingMachine is GenesisProtocol {
             "DXDVotingMachine: Address not registered in organizationRefounds"
         );
         require(organizationRefunds[msg.sender].balance > 0, "DXDVotingMachine: Organization refund balance is zero");
-        msg.sender.transfer(organizationRefunds[msg.sender].balance);
+        uint256 organizationBalance = organizationRefunds[msg.sender].balance;
         organizationRefunds[msg.sender].balance = 0;
+        msg.sender.transfer(organizationBalance);
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/DXgovernance/dxdao-contracts/issues/177

- update the internal state before making the external call (to protect against re-entry attacks)
- Tests are covered in `DXDVotingMachine.js`