### PR TITLE
Fix/add max amount actions

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -44,9 +44,9 @@ contract BaseERC20Guild {
     using ECDSAUpgradeable for bytes32;
     using AddressUpgradeable for address;
 
-    bytes4 public constant ERC20_TRANSFER_SIGNATURE = bytes4(keccak256("transfer(address,uint256)"));
-    bytes4 public constant ERC20_APPROVE_SIGNATURE = bytes4(keccak256("approve(address,uint256)"));
-    bytes4 public constant ANY_SIGNATURE = bytes4(0xaaaaaaaa);
+    // This configuration value is defined as constant to be protected against a malicious proposal
+    // changing it.
+    uint8 public constant MAX_ACTIONS_PER_PROPOSAL = 10;
 
     enum ProposalState {
         None,
@@ -239,6 +239,7 @@ contract BaseERC20Guild {
             totalActions <= to.length && value.length.mod(totalActions) == 0,
             "ERC20Guild: Invalid totalActions or action calls length"
         );
+        require(totalActions <= MAX_ACTIONS_PER_PROPOSAL, "ERC20Guild: Maximum amount of actions per proposal reached");
 
         bytes32 proposalId = keccak256(abi.encodePacked(msg.sender, block.timestamp, totalProposals));
         totalProposals = totalProposals.add(1);

--- a/contracts/erc20guild/implementations/GuardedERC20Guild.sol
+++ b/contracts/erc20guild/implementations/GuardedERC20Guild.sol
@@ -60,10 +60,10 @@ contract GuardedERC20Guild is ERC20GuildUpgradeable, OwnableUpgradeable {
     }
 
     // @dev Executes a proposal that is not votable anymore and can be finished
-    // If this function is called by the guild guardian the proposal can end sooner after proposal endTime
-    // If this function is not called by the guild guardian the proposal can end sooner after proposal endTime plus
+    // If this function is called by the guild guardian the proposal can end after proposal endTime
+    // If this function is not called by the guild guardian the proposal can end after proposal endTime plus
     // the extraTimeForGuardian
-    // @param proposalId The id of the proposal to be executed
+    // @param proposalId The id of the proposal to be ended
     function endProposal(bytes32 proposalId) public virtual override {
         require(proposals[proposalId].state == ProposalState.Active, "GuardedERC20Guild: Proposal already executed");
         if (msg.sender == guildGuardian)
@@ -80,7 +80,7 @@ contract GuardedERC20Guild is ERC20GuildUpgradeable, OwnableUpgradeable {
     }
 
     // @dev Rejects a proposal directly without execution, only callable by the guardian
-    // @param proposalId The id of the proposal to be executed
+    // @param proposalId The id of the proposal to be rejected
     function rejectProposal(bytes32 proposalId) external {
         require(proposals[proposalId].state == ProposalState.Active, "GuardedERC20Guild: Proposal already executed");
         require((msg.sender == guildGuardian), "GuardedERC20Guild: Proposal can be rejected only by guardian");

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -752,6 +752,29 @@ contract("ERC20Guild", function (accounts) {
 
       await createProposal(genericProposal);
     });
+
+    it("cannot create a proposal with more actions to the ones allowed", async function () {
+      await expectRevert(
+        createProposal({
+          guild: erc20Guild,
+          actions: [
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+            { to: [actionMockA.address], data: ["0x00"], value: ["1"] },
+          ],
+          account: accounts[3],
+        }),
+        "ERC20Guild: Maximum amount of actions per proposal reached"
+      );
+    });
   });
 
   describe("setVote", function () {


### PR DESCRIPTION
merge after #198 

Fix #163 

The attack shared on the audit report can be catastrophic, this is why we will recommend use the GuardedGuild or configure the ERC20Guild with the right parameters. Also this is why the max amount of actions per proposal is set as a constant, the only way to "change" it is to migrate or upgrade the ERC20Guild.