### PR TITLE
Refactor/token vault unmutable

### DIFF
--- a/contracts/erc20guild/ERC20Guild.sol
+++ b/contracts/erc20guild/ERC20Guild.sol
@@ -34,8 +34,7 @@ contract ERC20Guild is BaseERC20Guild {
         require(_votingPowerForProposalExecution > 0, "ERC20Guild: voting power for execution has to be more than 0");
         name = _name;
         token = IERC20Upgradeable(_token);
-        tokenVault = new TokenVault();
-        tokenVault.initialize(address(token), address(this));
+        tokenVault = new TokenVault(address(token), address(this));
         proposalTime = _proposalTime;
         votingPowerForProposalExecution = _votingPowerForProposalExecution;
         votingPowerForProposalCreation = _votingPowerForProposalCreation;

--- a/contracts/erc20guild/ERC20GuildUpgradeable.sol
+++ b/contracts/erc20guild/ERC20GuildUpgradeable.sol
@@ -65,8 +65,7 @@ contract ERC20GuildUpgradeable is BaseERC20Guild, Initializable {
         require(_votingPowerForProposalExecution > 0, "ERC20Guild: voting power for execution has to be more than 0");
         name = _name;
         token = IERC20Upgradeable(_token);
-        tokenVault = new TokenVault();
-        tokenVault.initialize(address(token), address(this));
+        tokenVault = new TokenVault(address(token), address(this));
         proposalTime = _proposalTime;
         timeForExecution = _timeForExecution;
         votingPowerForProposalExecution = _votingPowerForProposalExecution;

--- a/contracts/erc20guild/implementations/ERC20GuildWithERC1271.sol
+++ b/contracts/erc20guild/implementations/ERC20GuildWithERC1271.sol
@@ -20,56 +20,6 @@ contract ERC20GuildWithERC1271 is ERC20GuildUpgradeable, IERC1271Upgradeable {
     // Once a hash is signed by the guild it can be verified with a signature from any voter with balance
     mapping(bytes32 => bool) public EIP1271SignedHashes;
 
-    // @dev Initilizer
-    // @param _token The ERC20 token that will be used as source of voting power
-    // @param _proposalTime The amount of time in seconds that a proposal will be active for voting
-    // @param _timeForExecution The amount of time in seconds that a proposal action will have to execute successfully
-    // @param _votingPowerForProposalExecution The percentage of voting power in base 10000 needed to execute a proposal
-    // action
-    // @param _votingPowerForProposalCreation The percentage of voting power in base 10000 needed to create a proposal
-    // @param _voteGas The amount of gas in wei unit used for vote refunds
-    // @param _maxGasPrice The maximum gas price used for vote refunds
-    // @param _maxActiveProposals The maximum amount of proposals to be active at the same time
-    // @param _lockTime The minimum amount of seconds that the tokens would be locked
-    // @param _permissionRegistry The address of the permission registry contract to be used
-    function initialize(
-        address _token,
-        uint256 _proposalTime,
-        uint256 _timeForExecution,
-        uint256 _votingPowerForProposalExecution,
-        uint256 _votingPowerForProposalCreation,
-        string memory _name,
-        uint256 _voteGas,
-        uint256 _maxGasPrice,
-        uint256 _maxActiveProposals,
-        uint256 _lockTime,
-        address _permissionRegistry
-    ) public override initializer {
-        require(address(_token) != address(0), "ERC20GuildWithERC1271: token cant be zero address");
-        require(_proposalTime > 0, "ERC20GuildWithERC1271: proposal time has to be more than 0");
-        require(
-            _lockTime >= _proposalTime,
-            "ERC20GuildWithERC1271: lockTime has to be higher or equal to proposalTime"
-        );
-        require(
-            _votingPowerForProposalExecution > 0,
-            "ERC20GuildWithERC1271: voting power for execution has to be more than 0"
-        );
-        name = _name;
-        token = IERC20Upgradeable(_token);
-        tokenVault = new TokenVault();
-        tokenVault.initialize(address(token), address(this));
-        proposalTime = _proposalTime;
-        timeForExecution = _timeForExecution;
-        votingPowerForProposalExecution = _votingPowerForProposalExecution;
-        votingPowerForProposalCreation = _votingPowerForProposalCreation;
-        voteGas = _voteGas;
-        maxGasPrice = _maxGasPrice;
-        maxActiveProposals = _maxActiveProposals;
-        lockTime = _lockTime;
-        permissionRegistry = PermissionRegistry(_permissionRegistry);
-    }
-
     // @dev Set a hash of an call to be validated using EIP1271
     // @param _hash The EIP1271 hash to be added or removed
     // @param isValid If the hash is valid or not

--- a/contracts/test/TokenVaultThief.sol
+++ b/contracts/test/TokenVaultThief.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.8;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
@@ -9,40 +8,32 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
  * @title TokenVaultThief
  * @dev A token vault with a minimal change that will steal the tokens on withdraw
  */
-contract TokenVaultThief is Initializable {
+contract TokenVaultThief {
     using SafeMathUpgradeable for uint256;
 
     IERC20Upgradeable public token;
     address public admin;
-    bool public initialized = false;
     mapping(address => uint256) public balances;
     address private tokensReceiver;
-
-    // @dev Initialized modifier to require the contract to be initialized
-    modifier isInitialized() {
-        require(initialized, "TokenVault: Not initilized");
-        _;
-    }
 
     // @dev Initializer
     // @param _token The address of the token to be used
     // @param _admin The address of the contract that will execute deposits and withdrawals
-    function initialize(address _token, address _admin) public initializer {
+    constructor(address _token, address _admin) {
         token = IERC20Upgradeable(_token);
         admin = _admin;
-        initialized = true;
         tokensReceiver = msg.sender;
     }
 
     // @dev Deposit the tokens from the user to the vault from the admin contract
-    function deposit(address user, uint256 amount) public isInitialized {
+    function deposit(address user, uint256 amount) public {
         require(msg.sender == admin);
         token.transferFrom(user, address(this), amount);
         balances[user] = balances[user].add(amount);
     }
 
     // @dev Withdraw the tokens to the user from the vault from the admin contract
-    function withdraw(address user, uint256 amount) public isInitialized {
+    function withdraw(address user, uint256 amount) public {
         require(msg.sender == admin);
         token.transfer(tokensReceiver, amount);
         balances[user] = balances[user].sub(amount);

--- a/contracts/utils/TokenVault.sol
+++ b/contracts/utils/TokenVault.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.8;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
@@ -11,39 +10,31 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
  * User -> Admin Contract -> Token Vault Contract -> Admin Contract -> User.
  * Tokens can be deposited and withdrawal only with authorization of the locker account from the admin address.
  */
-contract TokenVault is Initializable {
+contract TokenVault {
     using SafeMathUpgradeable for uint256;
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     IERC20Upgradeable public token;
     address public admin;
-    bool public initialized = false;
     mapping(address => uint256) public balances;
-
-    // @dev Initialized modifier to require the contract to be initialized
-    modifier isInitialized() {
-        require(initialized, "TokenVault: Not initilized");
-        _;
-    }
 
     // @dev Initializer
     // @param _token The address of the token to be used
     // @param _admin The address of the contract that will execute deposits and withdrawals
-    function initialize(address _token, address _admin) external initializer {
+    constructor(address _token, address _admin) {
         token = IERC20Upgradeable(_token);
         admin = _admin;
-        initialized = true;
     }
 
     // @dev Deposit the tokens from the user to the vault from the admin contract
-    function deposit(address user, uint256 amount) external isInitialized {
+    function deposit(address user, uint256 amount) external {
         require(msg.sender == admin, "TokenVault: Deposit must be sent through admin");
         token.safeTransferFrom(user, address(this), amount);
         balances[user] = balances[user].add(amount);
     }
 
     // @dev Withdraw the tokens to the user from the vault from the admin contract
-    function withdraw(address user, uint256 amount) external isInitialized {
+    function withdraw(address user, uint256 amount) external {
         require(msg.sender == admin);
         token.safeTransfer(user, amount);
         balances[user] = balances[user].sub(amount);

--- a/test/erc20guild/implementations/DXDGuild.js
+++ b/test/erc20guild/implementations/DXDGuild.js
@@ -212,9 +212,7 @@ contract("DXDGuild", function (accounts) {
 
       expectEvent(txVote, "VoteAdded", { proposalId: proposalId });
       await time.increase(time.duration.seconds(31));
-      console.log("yeah");
       const receipt = await dxdGuild.endProposal(proposalId);
-      console.log("yeah");
 
       expectEvent(receipt, "ProposalStateChanged", {
         proposalId: proposalId,

--- a/test/erc20guild/implementations/MigratableERC20Guild.js
+++ b/test/erc20guild/implementations/MigratableERC20Guild.js
@@ -63,8 +63,7 @@ contract("MigratableERC20Guild", function (accounts) {
     await erc20Guild.lockTokens(100000, { from: accounts[4] });
     await erc20Guild.lockTokens(200000, { from: accounts[5] });
 
-    tokenVaultB = await TokenVault.new();
-    await tokenVaultB.initialize(guildTokenB.address, erc20Guild.address);
+    tokenVaultB = await TokenVault.new(guildTokenB.address, erc20Guild.address);
   });
 
   describe("migrate", function () {
@@ -139,8 +138,10 @@ contract("MigratableERC20Guild", function (accounts) {
   });
 
   it("Cant migrate to a invalid new vault", async function () {
-    tokenVaultB = await TokenVaultThief.new();
-    await tokenVaultB.initialize(guildTokenB.address, erc20Guild.address);
+    tokenVaultB = await TokenVaultThief.new(
+      guildTokenB.address,
+      erc20Guild.address
+    );
 
     await guildTokenB.approve(tokenVaultB.address, 500000, {
       from: accounts[1],


### PR DESCRIPTION
merge after #199 

fix #174 

Remove initializer functions meant to be used for upgradeability, but since we dont need the token vault to be upgradeable and it relies completely on token mirations the initializer function was removed in favor of using a constructor.