### PR TITLE
Refactor/dx reputation

### DIFF
--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.8;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /**
  * @title Reputation system
@@ -14,11 +13,11 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
  * This contract uses the ERC20SnapshotUpgradeable extension methods' under the hood to mint and burn reputation tokens.
  * It uses snapshots to keep track of the total reputation of each peer.
  */
-contract DxReputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+contract DxReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);
     event Burn(address indexed _from, uint256 _amount);
 
-    function initialize(string memory name, string memory symbol) public initializer {
+    function initialize(string memory name, string memory symbol) external initializer {
         __ERC20_init(name, symbol);
         __Ownable_init();
     }
@@ -27,14 +26,14 @@ contract DxReputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgrade
     // @param _user The address that will be assigned the new reputation
     // @param _amount The quantity of reputation generated
     // @return True if the reputation are generated correctly
-    function mint(address _user, uint256 _amount) public onlyOwner returns (bool) {
+    function mint(address _user, uint256 _amount) external onlyOwner returns (bool) {
         _mint(_user, _amount);
         _snapshot();
         emit Mint(_user, _amount);
         return true;
     }
 
-    function mintMultiple(address[] memory _user, uint256[] memory _amount) public onlyOwner returns (bool) {
+    function mintMultiple(address[] memory _user, uint256[] memory _amount) external onlyOwner returns (bool) {
         for (uint256 i = 0; i < _user.length; i++) {
             _mint(_user[i], _amount[i]);
             _snapshot();
@@ -47,14 +46,14 @@ contract DxReputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgrade
     // @param _user The address that will lose the reputation
     // @param _amount The quantity of reputation to burn
     // @return True if the reputation are burned correctly
-    function burn(address _user, uint256 _amount) public onlyOwner returns (bool) {
+    function burn(address _user, uint256 _amount) external onlyOwner returns (bool) {
         _burn(_user, _amount);
         _snapshot();
         emit Burn(_user, _amount);
         return true;
     }
 
-    function burnMultiple(address[] memory _user, uint256 _amount) public onlyOwner returns (bool) {
+    function burnMultiple(address[] memory _user, uint256 _amount) external onlyOwner returns (bool) {
         for (uint256 i = 0; i < _user.length; i++) {
             _burn(_user[i], _amount);
             _snapshot();

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.8;
 
-import "@openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /**
  * @title Reputation system

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -7,11 +7,12 @@ import "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.
 
 /**
  * @title Reputation system
+ * @author github:Kenny-Gin1
  * @dev A DAO has Reputation System which allows peers to rate other peers in order to build trust .
- * A reputation is use to assign influence measure to a DAO'S peers.
+ * Reputation is used to assign influence metric to a DAO's peers.
  * Reputation is similar to regular tokens but with one crucial difference: It is non-transferable.
- * The Reputation contract maintain a map of address to reputation value.
- * It provides an onlyOwner functions to mint and burn reputation _to (or _from) a specific address.
+ * This contract uses the ERC20SnapshotUpgradeable extension methods' under the hood to mint and burn reputation tokens.
+ * It uses snapshots to keep track of the total reputation of each peer.
  */
 contract Reputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -1,8 +1,76 @@
-pragma solidity ^0.5.4;
+pragma solidity 0.8.8;
 
-import "../daostack/controller/Reputation.sol";
+import "@openzeppelin/contracts-upgradeable/ownership/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/contracts/token/ERC20/extensions/ERC29SnapshotUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-// is Reputation
-contract DxReputation is Reputation {
-    constructor() public {}
+/**
+ * @title Reputation system
+ * @dev A DAO has Reputation System which allows peers to rate other peers in order to build trust .
+ * A reputation is use to assign influence measure to a DAO'S peers.
+ * Reputation is similar to regular tokens but with one crucial difference: It is non-transferable.
+ * The Reputation contract maintain a map of address to reputation value.
+ * It provides an onlyOwner functions to mint and burn reputation _to (or _from) a specific address.
+ */
+contract Reputation is Ownable, Initializable, ERC20SnapshotUpgradeable {
+    function initialize(string memory name, string memory symbol) public initializer {
+        _ERC20_init(name, symbol);
+        _Ownable_init();
+    }
+
+    function mint (address memory  _user, uint256 memory _amount) public onlyOwner {
+        require(token.balanceOf(msg.sender) >= _amount);
+        token.transfer(msg.sender, _amount);
+        token.transfer(_to, _amount);
+        emit Mint(_to, _amount);
+    }
+
+    // @notice Generates `_amount` reputation that are assigned to `_owner`
+    // @param _user The address that will be assigned the new reputation
+    // @param _amount The quantity of reputation generated
+    // @return True if the reputation are generated correctly
+    function mintMultiple(address[] memory _user, uint256[] memory _amount) public onlyOwner returns (bool) {
+        for (uint256 i = 0; i < _user.length; i++) {
+            uint256 curTotalSupply = totalSupply();
+            require(curTotalSupply + _amount[i] >= curTotalSupply); // Check for overflow
+            uint256 previousBalanceTo = balanceOf(_user[i]);
+            require(previousBalanceTo + _amount[i] >= previousBalanceTo); // Check for overflow
+            updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount[i]);
+            updateValueAtNow(balances[_user[i]], previousBalanceTo + _amount[i]);
+            emit Mint(_user[i], _amount[i]);
+        }
+        return true;
+    }
+
+    // @notice Burns `_amount` reputation from `_owner`
+    // @param _user The address that will lose the reputation
+    // @param _amount The quantity of reputation to burn
+    // @return True if the reputation are burned correctly
+    function burn(address _user, uint256 _amount) public onlyOwner returns (bool) {
+        uint256 curTotalSupply = totalSupply();
+        uint256 amountBurned = _amount;
+        uint256 previousBalanceFrom = balanceOf(_user);
+        if (previousBalanceFrom < amountBurned) {
+            amountBurned = previousBalanceFrom;
+        }
+        updateValueAtNow(totalSupplyHistory, curTotalSupply - amountBurned);
+        updateValueAtNow(balances[_user], previousBalanceFrom - amountBurned);
+        emit Burn(_user, amountBurned);
+        return true;
+    }
+
+    function burnMultiplie(address[] memory _user, uint256 _amount) public onlyOwner returns (bool) {
+        for (uint256 i = 0; i < _user.length; i++) {
+            uint256 curTotalSupply = totalSupply();
+            uint256 amountBurned = _amount;
+            uint256 previousBalanceFrom = balanceOf(_user[i]);
+            if (previousBalanceFrom < amountBurned) {
+                amountBurned = previousBalanceFrom;
+            }
+            updateValueAtNow(totalSupplyHistory, curTotalSupply - amountBurned);
+            updateValueAtNow(balances[_user[i]], previousBalanceFrom - amountBurned);
+            emit Burn(_user[i], amountBurned);
+        }
+        return true;
+    }
 }

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
  * This contract uses the ERC20SnapshotUpgradeable extension methods' under the hood to mint and burn reputation tokens.
  * It uses snapshots to keep track of the total reputation of each peer.
  */
-contract Reputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+contract DxReputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);
     event Burn(address indexed _from, uint256 _amount);
 

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.8;
 
-import "@openzeppelin/contracts-upgradeable/ownership/Ownable.sol";
-import "@openzeppelin/contracts-upgradeable/contracts/token/ERC20/extensions/ERC29SnapshotUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 
 /**
  * @title Reputation system
@@ -12,27 +13,26 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
  * The Reputation contract maintain a map of address to reputation value.
  * It provides an onlyOwner functions to mint and burn reputation _to (or _from) a specific address.
  */
-contract Reputation is Ownable, Initializable, ERC20SnapshotUpgradeable {
+contract Reputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);
-    // Event indicating burning of reputation for an address.
     event Burn(address indexed _from, uint256 _amount);
 
     function initialize(string memory name, string memory symbol) public initializer {
-        _ERC20_init(name, symbol);
-        _Ownable_init();
+        __ERC20_init(name, symbol);
+        __Ownable_init();
     }
 
-    function mint(address memory _user, uint256 memory _amount) public onlyOwner returns (bool) {
-        _mint(_user, _amount);
-        _snapshot();
-        emit Mint(_to, _amount);
-        return true;
-    }
-
-    // @notice Generates `_amount` reputation that are assigned to `_owner`
+    // @notice Generates `_amount` reputation that are assigned to `_user`
     // @param _user The address that will be assigned the new reputation
     // @param _amount The quantity of reputation generated
     // @return True if the reputation are generated correctly
+    function mint(address _user, uint256 _amount) public onlyOwner returns (bool) {
+        _mint(_user, _amount);
+        _snapshot();
+        emit Mint(_user, _amount);
+        return true;
+    }
+
     function mintMultiple(address[] memory _user, uint256[] memory _amount) public onlyOwner returns (bool) {
         for (uint256 i = 0; i < _user.length; i++) {
             _mint(_user[i], _amount[i]);
@@ -42,22 +42,22 @@ contract Reputation is Ownable, Initializable, ERC20SnapshotUpgradeable {
         return true;
     }
 
-    // @notice Burns `_amount` reputation from `_owner`
+    // @notice Burns `_amount` reputation from `_user`
     // @param _user The address that will lose the reputation
     // @param _amount The quantity of reputation to burn
     // @return True if the reputation are burned correctly
     function burn(address _user, uint256 _amount) public onlyOwner returns (bool) {
         _burn(_user, _amount);
         _snapshot();
-        emit Burn(_user, amount);
+        emit Burn(_user, _amount);
         return true;
     }
 
-    function burnMultiplie(address[] memory _user, uint256 _amount) public onlyOwner returns (bool) {
+    function burnMultiple(address[] memory _user, uint256 _amount) public onlyOwner returns (bool) {
         for (uint256 i = 0; i < _user.length; i++) {
             _burn(_user[i], _amount);
             _snapshot();
-            emit Burn(_user[i], amount);
+            emit Burn(_user[i], _amount);
         }
         return true;
     }

--- a/contracts/dxdao/DxReputation.sol
+++ b/contracts/dxdao/DxReputation.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
  * This contract uses the ERC20SnapshotUpgradeable extension methods' under the hood to mint and burn reputation tokens.
  * It uses snapshots to keep track of the total reputation of each peer.
  */
-contract DxReputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+contract Reputation is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);
     event Burn(address indexed _from, uint256 _amount);
 

--- a/test/daostack/Controller.js
+++ b/test/daostack/Controller.js
@@ -24,7 +24,7 @@ const setup = async function (
   token = await DxToken.new("TEST", "TST", 0);
   // set up a reputation system
   reputation = await DxReputation.new();
-
+  await reputation.initialize("REPUTATION", "REP");
   avatar = await DxAvatar.new("name", token.address, reputation.address);
   var sender = accounts[0];
   if (permission !== "0") {


### PR DESCRIPTION
Closes: https://github.com/DXgovernance/dxdao-contracts/issues/204

Description:
Refactor the DXReputation using `ERC20SnapshotUpgradeable` contracts and its underlying methods. In this refactor we use `mint`, `burn`, and the `snapshot` method to update a user's current REP.

It's also able to `mintMultiple` and `burnMultiple`.

Tested and it compiles for version `0.8.8`.