### PR TITLE
feat: Transferring ownership of rep token in deployment

### DIFF
--- a/scripts/utils/deploy-guilds.js
+++ b/scripts/utils/deploy-guilds.js
@@ -28,8 +28,15 @@ const deployGuilds = async function (guilds, networkContracts) {
     );
     await waitBlocks(1);
 
-    if (guildToDeploy.contractName === "SnapshotRepERC20Guild")
+    if (guildToDeploy.contractName === "SnapshotRepERC20Guild") {
       await newGuild.transferOwnership(newGuild.address);
+
+      const ERC20SnapshotRep = await hre.artifacts.require("ERC20SnapshotRep");
+      const rep = await ERC20SnapshotRep.at(
+        networkContracts.addresses[guildToDeploy.token]
+      );
+      await rep.transferOwnership(newGuild.address);
+    }
 
     networkContracts.addresses[guildToDeploy.name] = newGuild.address;
     networkContracts.addresses[guildToDeploy.name + "-vault"] =


### PR DESCRIPTION
We dont transfer ownership here and currently do it on FE side for localhost but this is also needed for goerli deployments and basically anytime we use rep guilds.
This needs removed from dev.ts to run in local development