### PR TITLE
Try frontrun eth permission check

### DIFF
--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -182,6 +182,9 @@ contract PermissionRegistry is OwnableUpgradeable {
         bytes4 functionSignature,
         uint256 valueTransferred
     ) public {
+        if (msg.sender != owner()) {
+            require(from == msg.sender, "PermissionRegistry: Only owner can specify from value");
+        }
         if (valueTransferred > 0) {
             _setValueTransferred(ethPermissions[from][address(0)][bytes4(0)], valueTransferred);
         }

--- a/test/dxvote/WalletScheme.js
+++ b/test/dxvote/WalletScheme.js
@@ -247,6 +247,8 @@ contract("WalletScheme", function (accounts) {
       value: 1000,
     });
 
+    await permissionRegistry.transferOwnership(org.avatar.address);
+
     const newWalletScheme = await WalletScheme.new();
     await newWalletScheme.initialize(
       org.avatar.address,
@@ -411,13 +413,13 @@ contract("WalletScheme", function (accounts) {
       ),
       "_proposalId"
     );
+
     await expectRevert(
       votingMachine.contract.vote(proposalId1, 1, 0, constants.NULL_ADDRESS, {
         from: accounts[2],
       }),
-      "call execution failed"
+      "WalletScheme: call execution failed"
     );
-
     const proposalId2 = await helpers.getValueFromLogs(
       await masterWalletScheme.proposeCalls(
         [org.controller.address],
@@ -432,7 +434,7 @@ contract("WalletScheme", function (accounts) {
       votingMachine.contract.vote(proposalId2, 1, 0, constants.NULL_ADDRESS, {
         from: accounts[2],
       }),
-      "call execution failed"
+      "WalletScheme: call execution failed"
     );
 
     const proposalId3 = await helpers.getValueFromLogs(
@@ -1054,7 +1056,7 @@ contract("WalletScheme", function (accounts) {
       votingMachine.contract.vote(proposalId, 1, 0, constants.NULL_ADDRESS, {
         from: accounts[2],
       }),
-      "PermissionRegistry: Call not allowed"
+      "WalletScheme: permission check failed"
     );
 
     assert.equal(
@@ -1117,7 +1119,7 @@ contract("WalletScheme", function (accounts) {
       votingMachine.contract.vote(proposalId, 1, 0, constants.NULL_ADDRESS, {
         from: accounts[2],
       }),
-      "PermissionRegistry: Value limit reached"
+      "WalletScheme: permission check failed"
     );
 
     assert.equal(
@@ -1157,6 +1159,7 @@ contract("WalletScheme", function (accounts) {
       true
     );
 
+    await time.increase(31);
     const callData = helpers.testCallFrom(org.avatar.address);
 
     const tx = await masterWalletScheme.proposeCalls(
@@ -1171,7 +1174,7 @@ contract("WalletScheme", function (accounts) {
       votingMachine.contract.vote(proposalId, 1, 0, constants.NULL_ADDRESS, {
         from: accounts[2],
       }),
-      "PermissionRegistry: Value limit reached"
+      "WalletScheme: permission check failed"
     );
 
     assert.equal(


### PR DESCRIPTION
Add tests to try to frontrun the value transferred of ETH between calls in a proposal execution of the guild, by calling `setETHPermissionUsed` between calls, but failing in executing the attack since the `setETHPermissionUsed` function can only increase the value transferred and it uses safeMath so it is impossible to lower the value transferred in the proposal execution and transfer a higher value to the one allowed.

Despite the failed execution of the attack another check was added to the `from` variable in the `setETHPermissionUsed` function to check that the permission is being set by the owner of the permission regsitry or by the contract owner itself.