### PR TITLE
fix A2-A4 recommendations by omega

### DIFF
--- a/contracts/dao/schemes/AvatarScheme.sol
+++ b/contracts/dao/schemes/AvatarScheme.sol
@@ -68,15 +68,6 @@ contract AvatarScheme is Scheme {
         } else {
             uint256 oldRepSupply = getNativeReputationTotalSupply();
 
-            // Cant mint or burn more REP than the allowed percentaged set in the wallet scheme initialization
-            require(
-                (oldRepSupply.mul(uint256(100).add(maxRepPercentageChange)).div(100) >=
-                    getNativeReputationTotalSupply()) &&
-                    (oldRepSupply.mul(uint256(100).sub(maxRepPercentageChange)).div(100) <=
-                        getNativeReputationTotalSupply()),
-                "AvatarScheme: maxRepPercentageChange passed"
-            );
-
             require(permissionRegistry.checkERC20Limits(address(avatar)), "AvatarScheme: ERC20 limits passed");
             proposal.state = ProposalState.ExecutionSucceeded;
             emit ProposalStateChange(_proposalId, uint256(ProposalState.ExecutionSucceeded));
@@ -121,6 +112,14 @@ contract AvatarScheme is Scheme {
                 );
                 require(callsSucessResult, "AvatarScheme: Proposal call failed");
             }
+            // Cant mint or burn more REP than the allowed percentaged set in the wallet scheme initialization
+            require(
+                (oldRepSupply.mul(uint256(100).add(maxRepPercentageChange)).div(100) >=
+                    getNativeReputationTotalSupply()) &&
+                    (oldRepSupply.mul(uint256(100).sub(maxRepPercentageChange)).div(100) <=
+                        getNativeReputationTotalSupply()),
+                "AvatarScheme: maxRepPercentageChange passed"
+            );
         }
         controller.endProposal(_proposalId);
         executingProposal = false;

--- a/contracts/dao/schemes/AvatarScheme.sol
+++ b/contracts/dao/schemes/AvatarScheme.sol
@@ -67,8 +67,6 @@ contract AvatarScheme is Scheme {
             emit ProposalStateChange(_proposalId, uint256(ProposalState.Rejected));
         } else {
             uint256 oldRepSupply = getNativeReputationTotalSupply();
-
-            require(permissionRegistry.checkERC20Limits(address(avatar)), "AvatarScheme: ERC20 limits passed");
             proposal.state = ProposalState.ExecutionSucceeded;
             emit ProposalStateChange(_proposalId, uint256(ProposalState.ExecutionSucceeded));
 
@@ -120,6 +118,7 @@ contract AvatarScheme is Scheme {
                         getNativeReputationTotalSupply()),
                 "AvatarScheme: maxRepPercentageChange passed"
             );
+            require(permissionRegistry.checkERC20Limits(address(avatar)), "AvatarScheme: ERC20 limits passed");
         }
         controller.endProposal(_proposalId);
         executingProposal = false;

--- a/contracts/dao/schemes/AvatarScheme.sol
+++ b/contracts/dao/schemes/AvatarScheme.sol
@@ -8,8 +8,8 @@ import "./Scheme.sol";
 /**
  * @title AvatarScheme.
  * @dev  A scheme for proposing and executing calls to any contract from the DAO avatar
- * It has a value call controller address, in case of the controller address ot be set the scheme will be doing
- * generic calls to the dao controller. If the controller address is not set it will e executing raw calls form the
+ * It has a value call controller address, in case the controller address is set the scheme will be doing
+ * generic calls to the dao controller. If the controller address is not set it will e executing raw calls from the
  * scheme itself.
  * The scheme can only execute calls allowed to in the permission registry, if the controller address is set
  * the permissions will be checked using the avatar address as sender, if not the scheme address will be used as
@@ -56,11 +56,6 @@ contract AvatarScheme is Scheme {
         Proposal storage proposal = proposals[_proposalId];
         require(proposal.state == ProposalState.Submitted, "AvatarScheme: must be a submitted proposal");
 
-        require(
-            controller.getSchemeCanMakeAvatarCalls(address(this)),
-            "AvatarScheme: scheme have to make avatar calls"
-        );
-
         if (proposal.submittedTime.add(maxSecondsForExecution) < block.timestamp) {
             // If the amount of time passed since submission plus max proposal time is lower than block timestamp
             // the proposal timeout execution is reached and proposal cant be executed from now on
@@ -72,6 +67,19 @@ contract AvatarScheme is Scheme {
             emit ProposalStateChange(_proposalId, uint256(ProposalState.Rejected));
         } else {
             uint256 oldRepSupply = getNativeReputationTotalSupply();
+
+            // Cant mint or burn more REP than the allowed percentaged set in the wallet scheme initialization
+            require(
+                (oldRepSupply.mul(uint256(100).add(maxRepPercentageChange)).div(100) >=
+                    getNativeReputationTotalSupply()) &&
+                    (oldRepSupply.mul(uint256(100).sub(maxRepPercentageChange)).div(100) <=
+                        getNativeReputationTotalSupply()),
+                "AvatarScheme: maxRepPercentageChange passed"
+            );
+
+            require(permissionRegistry.checkERC20Limits(address(avatar)), "AvatarScheme: ERC20 limits passed");
+            proposal.state = ProposalState.ExecutionSucceeded;
+            emit ProposalStateChange(_proposalId, uint256(ProposalState.ExecutionSucceeded));
 
             controller.avatarCall(
                 address(permissionRegistry),
@@ -112,22 +120,7 @@ contract AvatarScheme is Scheme {
                     proposal.value[callIndex]
                 );
                 require(callsSucessResult, "AvatarScheme: Proposal call failed");
-
-                proposal.state = ProposalState.ExecutionSucceeded;
             }
-
-            // Cant mint or burn more REP than the allowed percentaged set in the wallet scheme initialization
-            require(
-                (oldRepSupply.mul(uint256(100).add(maxRepPercentageChange)).div(100) >=
-                    getNativeReputationTotalSupply()) &&
-                    (oldRepSupply.mul(uint256(100).sub(maxRepPercentageChange)).div(100) <=
-                        getNativeReputationTotalSupply()),
-                "AvatarScheme: maxRepPercentageChange passed"
-            );
-
-            require(permissionRegistry.checkERC20Limits(address(avatar)), "AvatarScheme: ERC20 limits passed");
-
-            emit ProposalStateChange(_proposalId, uint256(ProposalState.ExecutionSucceeded));
         }
         controller.endProposal(_proposalId);
         executingProposal = false;

--- a/contracts/dao/schemes/WalletScheme.sol
+++ b/contracts/dao/schemes/WalletScheme.sol
@@ -59,11 +59,6 @@ contract WalletScheme is Scheme {
         Proposal storage proposal = proposals[_proposalId];
         require(proposal.state == ProposalState.Submitted, "WalletScheme: must be a submitted proposal");
 
-        require(
-            !controller.getSchemeCanMakeAvatarCalls(address(this)),
-            "WalletScheme: scheme cannot make avatar calls"
-        );
-
         if (proposal.submittedTime.add(maxSecondsForExecution) < block.timestamp) {
             // If the amount of time passed since submission plus max proposal time is lower than block timestamp
             // the proposal timeout execution is reached and proposal cant be executed from now on

--- a/test/dao/schemes/AvatarScheme.js
+++ b/test/dao/schemes/AvatarScheme.js
@@ -16,15 +16,13 @@ contract("AvatarScheme", function (accounts) {
     avatarScheme,
     walletScheme,
     org,
-    actionMock,
-    testToken;
+    actionMock;
 
   const constants = helpers.constants;
   const executionTimeout = 172800 + 86400; // _queuedVotePeriodLimit + _boostedVotePeriodLimit
 
   beforeEach(async function () {
     actionMock = await ActionMock.new();
-    testToken = await ERC20Mock.new("", "", 1000, accounts[1]);
     standardTokenMock = await ERC20Mock.new("", "", 1000, accounts[1]);
 
     org = await helpers.deployDao({
@@ -43,17 +41,6 @@ contract("AvatarScheme", function (accounts) {
 
     permissionRegistry = await PermissionRegistry.new(accounts[0], 30);
     await permissionRegistry.initialize();
-
-    registrarScheme = await WalletScheme.new();
-    await registrarScheme.initialize(
-      org.avatar.address,
-      org.votingMachine.address,
-      org.controller.address,
-      permissionRegistry.address,
-      "Wallet Scheme Registrar",
-      executionTimeout,
-      0
-    );
 
     avatarScheme = await AvatarScheme.new();
     await avatarScheme.initialize(
@@ -79,67 +66,6 @@ contract("AvatarScheme", function (accounts) {
 
     await permissionRegistry.setETHPermission(
       org.avatar.address,
-      constants.NULL_ADDRESS,
-      constants.NULL_SIGNATURE,
-      constants.MAX_UINT_256,
-      true
-    );
-
-    await permissionRegistry.setETHPermission(
-      registrarScheme.address,
-      org.controller.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "registerScheme(address,bytes32,bool,bool)"
-      ),
-      0,
-      true
-    );
-
-    await permissionRegistry.setETHPermission(
-      registrarScheme.address,
-      org.controller.address,
-      web3.eth.abi.encodeFunctionSignature("unregisterScheme(address)"),
-      0,
-      true
-    );
-
-    await permissionRegistry.setETHPermission(
-      walletScheme.address,
-      constants.NULL_ADDRESS,
-      constants.NULL_SIGNATURE,
-      constants.MAX_UINT_256,
-      true
-    );
-
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
-      registrarScheme.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "setMaxSecondsForExecution(uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
-      avatarScheme.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "setMaxSecondsForExecution(uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
-      walletScheme.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "setMaxSecondsForExecution(uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
       actionMock.address,
       web3.eth.abi.encodeFunctionSignature("test(address,uint256)"),
       0,
@@ -148,49 +74,6 @@ contract("AvatarScheme", function (accounts) {
 
     await permissionRegistry.setETHPermission(
       org.avatar.address,
-      actionMock.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "executeCall(address,bytes,uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
-      actionMock.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "executeCallWithRequiredSuccess(address,bytes,uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      org.avatar.address,
-      actionMock.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "testWithoutReturnValue(address,uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      walletScheme.address,
-      actionMock.address,
-      web3.eth.abi.encodeFunctionSignature(
-        "testWithoutReturnValue(address,uint256)"
-      ),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      walletScheme.address,
-      actionMock.address,
-      web3.eth.abi.encodeFunctionSignature("test(address,uint256)"),
-      0,
-      true
-    );
-    await permissionRegistry.setETHPermission(
-      walletScheme.address,
       actionMock.address,
       web3.eth.abi.encodeFunctionSignature(
         "executeCall(address,bytes,uint256)"
@@ -202,22 +85,10 @@ contract("AvatarScheme", function (accounts) {
     await time.increase(30);
 
     await org.controller.registerScheme(
-      registrarScheme.address,
-      defaultParamsHash,
-      true,
-      false
-    );
-    await org.controller.registerScheme(
       avatarScheme.address,
       defaultParamsHash,
       false,
       true
-    );
-    await org.controller.registerScheme(
-      walletScheme.address,
-      defaultParamsHash,
-      false,
-      false
     );
   });
   it("should execute proposal", async function () {
@@ -245,7 +116,6 @@ contract("AvatarScheme", function (accounts) {
     const organizationProposal = await avatarScheme.getOrganizationProposal(
       proposalId
     );
-
     assert.equal(
       organizationProposal.state,
       constants.WALLET_SCHEME_PROPOSAL_STATES.executionSuccedd

--- a/test/dao/schemes/AvatarScheme.js
+++ b/test/dao/schemes/AvatarScheme.js
@@ -1,0 +1,254 @@
+import { artifacts } from "hardhat";
+import * as helpers from "../../helpers";
+import { assert } from "chai";
+const { time } = require("@openzeppelin/test-helpers");
+
+const AvatarScheme = artifacts.require("./AvatarScheme.sol");
+const WalletScheme = artifacts.require("./WalletScheme.sol");
+const PermissionRegistry = artifacts.require("./PermissionRegistry.sol");
+const ERC20Mock = artifacts.require("./ERC20Mock.sol");
+const ActionMock = artifacts.require("./ActionMock.sol");
+
+contract("AvatarScheme", function (accounts) {
+  let standardTokenMock,
+    permissionRegistry,
+    registrarScheme,
+    avatarScheme,
+    walletScheme,
+    org,
+    actionMock,
+    testToken;
+
+  const constants = helpers.constants;
+  const executionTimeout = 172800 + 86400; // _queuedVotePeriodLimit + _boostedVotePeriodLimit
+
+  beforeEach(async function () {
+    actionMock = await ActionMock.new();
+    testToken = await ERC20Mock.new("", "", 1000, accounts[1]);
+    standardTokenMock = await ERC20Mock.new("", "", 1000, accounts[1]);
+
+    org = await helpers.deployDao({
+      owner: accounts[0],
+      votingMachineToken: standardTokenMock.address,
+      repHolders: [
+        { address: accounts[0], amount: 20000 },
+        { address: accounts[1], amount: 10000 },
+        { address: accounts[2], amount: 70000 },
+      ],
+    });
+
+    const defaultParamsHash = await helpers.setDefaultParameters(
+      org.votingMachine
+    );
+
+    permissionRegistry = await PermissionRegistry.new(accounts[0], 30);
+    await permissionRegistry.initialize();
+
+    registrarScheme = await WalletScheme.new();
+    await registrarScheme.initialize(
+      org.avatar.address,
+      org.votingMachine.address,
+      org.controller.address,
+      permissionRegistry.address,
+      "Wallet Scheme Registrar",
+      executionTimeout,
+      0
+    );
+
+    avatarScheme = await AvatarScheme.new();
+    await avatarScheme.initialize(
+      org.avatar.address,
+      org.votingMachine.address,
+      org.controller.address,
+      permissionRegistry.address,
+      "Master Wallet",
+      executionTimeout,
+      5
+    );
+
+    walletScheme = await WalletScheme.new();
+    await walletScheme.initialize(
+      org.avatar.address,
+      org.votingMachine.address,
+      org.controller.address,
+      permissionRegistry.address,
+      "Quick Wallet",
+      executionTimeout,
+      1
+    );
+
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      constants.NULL_ADDRESS,
+      constants.NULL_SIGNATURE,
+      constants.MAX_UINT_256,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      registrarScheme.address,
+      org.controller.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "registerScheme(address,bytes32,bool,bool)"
+      ),
+      0,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      registrarScheme.address,
+      org.controller.address,
+      web3.eth.abi.encodeFunctionSignature("unregisterScheme(address)"),
+      0,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      walletScheme.address,
+      constants.NULL_ADDRESS,
+      constants.NULL_SIGNATURE,
+      constants.MAX_UINT_256,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      registrarScheme.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "setMaxSecondsForExecution(uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      avatarScheme.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "setMaxSecondsForExecution(uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      walletScheme.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "setMaxSecondsForExecution(uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature("test(address,uint256)"),
+      0,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "executeCall(address,bytes,uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "executeCallWithRequiredSuccess(address,bytes,uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "testWithoutReturnValue(address,uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      walletScheme.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "testWithoutReturnValue(address,uint256)"
+      ),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      walletScheme.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature("test(address,uint256)"),
+      0,
+      true
+    );
+    await permissionRegistry.setETHPermission(
+      walletScheme.address,
+      actionMock.address,
+      web3.eth.abi.encodeFunctionSignature(
+        "executeCall(address,bytes,uint256)"
+      ),
+      0,
+      true
+    );
+
+    await time.increase(30);
+
+    await org.controller.registerScheme(
+      registrarScheme.address,
+      defaultParamsHash,
+      true,
+      false
+    );
+    await org.controller.registerScheme(
+      avatarScheme.address,
+      defaultParamsHash,
+      false,
+      true
+    );
+    await org.controller.registerScheme(
+      walletScheme.address,
+      defaultParamsHash,
+      false,
+      false
+    );
+  });
+  it("should execute proposal", async function () {
+    const callData = helpers.testCallFrom(org.avatar.address);
+
+    await permissionRegistry.setETHPermission(
+      org.avatar.address,
+      accounts[1],
+      callData.substring(0, 10),
+      0,
+      true
+    );
+    const tx = await avatarScheme.proposeCalls(
+      [actionMock.address],
+      [callData],
+      [0],
+      2,
+      constants.TEST_TITLE,
+      constants.SOME_HASH
+    );
+    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    await org.votingMachine.vote(proposalId, 1, 0, constants.NULL_ADDRESS, {
+      from: accounts[2],
+    });
+    const organizationProposal = await avatarScheme.getOrganizationProposal(
+      proposalId
+    );
+
+    assert.equal(
+      organizationProposal.state,
+      constants.WALLET_SCHEME_PROPOSAL_STATES.executionSuccedd
+    );
+  });
+});


### PR DESCRIPTION
Closes: 
#242 #243 #244 

**Description**
This PR refers to the findings of Omega, namely A2 - A4. Concretely it fixes the following: 

- Setting the `ProposalState.ExecutionSucceeded` outside of the loop to avoid multiple updates to the proposal state.
- Following the `[checks-effects-interactions`-pattern](https://docs.soliditylang.org/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern) and moving the proposal state changes before the external calls.
- Removing the `require` criterion that checks if the scheme is approved to make avatar calls since this require is redunadnt.