### PR TITLE
C1. DAOController: Allow specifying the paramshash that is passed to the …

### DIFF
--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -43,9 +43,13 @@ contract DAOController is Initializable {
     event RegisterScheme(address indexed _sender, address indexed _scheme);
     event UnregisterScheme(address indexed _sender, address indexed _scheme);
 
-    function initialize(address _scheme, address _reputationToken) public initializer {
+    function initialize(
+        address _scheme,
+        address _reputationToken,
+        bytes32 _paramsHash
+    ) public initializer {
         schemes[_scheme] = Scheme({
-            paramsHash: bytes32(0),
+            paramsHash: _paramsHash,
             isRegistered: true,
             canManageSchemes: true,
             canMakeAvatarCalls: true

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -59,7 +59,6 @@ export const deployDao = async function (deployConfig) {
   await reputation.initialize("DXDaoReputation", "DXRep");
 
   const controller = await DAOController.new();
-  await controller.initialize(deployConfig.owner, reputation.address);
 
   const avatar = await DAOAvatar.new();
   await avatar.initialize(controller.address);
@@ -75,6 +74,14 @@ export const deployDao = async function (deployConfig) {
   const votingMachine = await DXDVotingMachine.new(
     deployConfig.votingMachineToken,
     avatar.address
+  );
+
+  const defaultParamsHash = await setDefaultParameters(votingMachine);
+
+  await controller.initialize(
+    deployConfig.owner,
+    reputation.address,
+    defaultParamsHash
   );
 
   return { controller, avatar, reputation, votingMachine };


### PR DESCRIPTION
### Description
DAOController: Allow specifying the `paramshash` that is passed to the initialize function.

Closes https://github.com/DXgovernance/dxdao-contracts/issues/226