### PR TITLE
R1 - snapshot is called unnecessarily too often

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ An ERC20Guild with the functionality to migrate the ERC20 voting token used, the
 
 #### SnapshotERC20Guild
 
-An ERC20Guild that keeps track of the voting power by saving a snapshot of the voting power each time a lock/withdraw of tokens happens. The voting power to be used on a proposal would be the one that the guild had at the moment of the proposal creation.
+An ERC20Guild that keeps track of the voting power by saving a snapshot of the voting power each time a mint/burn of tokens happens. The voting power to be used on a proposal would be the one that the guild had at the moment of the proposal creation.
 
 #### SnapshotERC20REPGuild
 

--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -159,7 +159,6 @@ contract DAOController is Initializable {
     function startProposal(bytes32 _proposalId) external onlyRegisteredScheme {
         activeProposals.add(_proposalId);
         schemeOfProposal[_proposalId] = msg.sender;
-        reputationToken.takeSnapshot();
     }
 
     /**

--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -159,6 +159,7 @@ contract DAOController is Initializable {
     function startProposal(bytes32 _proposalId) external onlyRegisteredScheme {
         activeProposals.add(_proposalId);
         schemeOfProposal[_proposalId] = msg.sender;
+        reputationToken.takeSnaphost();
     }
 
     /**

--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -159,7 +159,7 @@ contract DAOController is Initializable {
     function startProposal(bytes32 _proposalId) external onlyRegisteredScheme {
         activeProposals.add(_proposalId);
         schemeOfProposal[_proposalId] = msg.sender;
-        reputationToken.takeSnaphost();
+        reputationToken.takeSnapshot();
     }
 
     /**

--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -74,7 +74,7 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     /**
      * @dev Get the current snapshotId
      */
-    function takeSnaphost() external onlyOwner returns (uint256) {
+    function takeSnapshot() external onlyOwner returns (uint256) {
         return _snapshot();
     }
 }

--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -34,7 +34,6 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     // @return True if the reputation are generated correctly
     function mint(address _account, uint256 _amount) external onlyOwner returns (bool) {
         _mint(_account, _amount);
-        _snapshot();
         emit Mint(_account, _amount);
         return true;
     }
@@ -42,7 +41,6 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     function mintMultiple(address[] memory _accounts, uint256[] memory _amount) external onlyOwner returns (bool) {
         for (uint256 i = 0; i < _accounts.length; i++) {
             _mint(_accounts[i], _amount[i]);
-            _snapshot();
             emit Mint(_accounts[i], _amount[i]);
         }
         return true;
@@ -54,7 +52,6 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     // @return True if the reputation are burned correctly
     function burn(address _account, uint256 _amount) external onlyOwner returns (bool) {
         _burn(_account, _amount);
-        _snapshot();
         emit Burn(_account, _amount);
         return true;
     }
@@ -62,7 +59,6 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     function burnMultiple(address[] memory _accounts, uint256 _amount) external onlyOwner returns (bool) {
         for (uint256 i = 0; i < _accounts.length; i++) {
             _burn(_accounts[i], _amount);
-            _snapshot();
             emit Burn(_accounts[i], _amount);
         }
         return true;
@@ -73,5 +69,12 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
      */
     function getCurrentSnapshotId() public view returns (uint256) {
         return _getCurrentSnapshotId();
+    }
+
+    /**
+     * @dev Get the current snapshotId
+     */
+    function takeSnaphost() external onlyOwner returns (uint256) {
+        return _snapshot();
     }
 }

--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20Snapshot
  * @title DAO Reputation
  * @dev An ERC20 token that is non-transferable, owned and controlled by the DAO.
  * Used by the DAO to vote on proposals.
- * It uses a snapshot mechanism to keep track of the reputation at the moment of each proposal creation.
+ * It uses a snapshot mechanism to keep track of the reputation at the moment of each modification of the supply of the token (every mint an burn).
  */
 contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     event Mint(address indexed _to, uint256 _amount);
@@ -34,6 +34,7 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     // @return True if the reputation are generated correctly
     function mint(address _account, uint256 _amount) external onlyOwner returns (bool) {
         _mint(_account, _amount);
+        _snapshot();
         emit Mint(_account, _amount);
         return true;
     }
@@ -52,6 +53,7 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     // @return True if the reputation are burned correctly
     function burn(address _account, uint256 _amount) external onlyOwner returns (bool) {
         _burn(_account, _amount);
+        _snapshot();
         emit Burn(_account, _amount);
         return true;
     }
@@ -69,12 +71,5 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
      */
     function getCurrentSnapshotId() public view returns (uint256) {
         return _getCurrentSnapshotId();
-    }
-
-    /**
-     * @dev Get the current snapshotId
-     */
-    function takeSnapshot() external onlyOwner returns (uint256) {
-        return _snapshot();
     }
 }


### PR DESCRIPTION
Closes: #239 

**Description**
The problem on this item was that we were taking a snapshot each time we minted or burned REP. This is unnecesary because the only moment we need the snapshot is when we are creating a proposal. 
The solution i did was only taking a snapshot when creating a proposal (on DAOController.sol). 
This has a (negative?) consequence, that the snapshot is not updated all the time, so if someone calls getCurrentSnapshotId() may not get the correct snapshot. 

At the moment this is not a problem because every time this function is called is when a proposal is being created, but maybe it could be a problem in the future. 

I talked to @dcrescimbeni and we agreed to do this, and ask here for your comments so let me know  what you think. 