### PR TITLE
Fix/add dxdvotingmachine interface in Scheme - S4

### DIFF
--- a/contracts/dao/schemes/Scheme.sol
+++ b/contracts/dao/schemes/Scheme.sol
@@ -85,7 +85,7 @@ abstract contract Scheme is DXDVotingMachineCallbacks {
             "WalletScheme: _maxSecondsForExecution cant be less than 86400 seconds"
         );
         avatar = DAOAvatar(_avatar);
-        votingMachine = _votingMachine;
+        votingMachine = IDXDVotingMachine(_votingMachine);
         controller = DAOController(_controller);
         permissionRegistry = PermissionRegistry(_permissionRegistry);
         schemeName = _schemeName;
@@ -159,20 +159,7 @@ abstract contract Scheme is DXDVotingMachineCallbacks {
         bytes32 voteParams = controller.getSchemeParameters(address(this));
 
         // Get the proposal id that will be used from the voting machine
-        // bytes32 proposalId = votingMachine.propose(_totalOptions, voteParams, msg.sender, address(avatar));
-        bytes32 proposalId = abi.decode(
-            votingMachine.functionCall(
-                abi.encodeWithSignature(
-                    "propose(uint256,bytes32,address,address)",
-                    _totalOptions,
-                    voteParams,
-                    msg.sender,
-                    avatar
-                ),
-                "WalletScheme: DXDVotingMachine callback propose error"
-            ),
-            (bytes32)
-        );
+        bytes32 proposalId = votingMachine.propose(_totalOptions, voteParams, msg.sender, address(avatar));
 
         controller.startProposal(proposalId);
 

--- a/contracts/dao/votingMachine/DXDVotingMachineCallbacks.sol
+++ b/contracts/dao/votingMachine/DXDVotingMachineCallbacks.sol
@@ -5,15 +5,15 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../DAOController.sol";
 import "../DAOReputation.sol";
 import "hardhat/console.sol";
+import "./IDXDVotingMachine.sol";
 
 contract DXDVotingMachineCallbacks {
-    address public votingMachine;
+    IDXDVotingMachine public votingMachine;
 
     DAOController public controller;
 
     modifier onlyVotingMachine() {
         require(msg.sender == address(votingMachine), "DXDVotingMachineCallbacks: only VotingMachine");
-
         _;
     }
 

--- a/contracts/dao/votingMachine/IDXDVotingMachine.sol
+++ b/contracts/dao/votingMachine/IDXDVotingMachine.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.17;
+
+interface IDXDVotingMachine {
+    function propose(
+        uint256,
+        bytes32 _paramsHash,
+        address _proposer,
+        address _organization
+    ) external returns (bytes32);
+}


### PR DESCRIPTION
The call on line 164 to the propose function of the voting machine is done using functionCall instead
of calling the propose function directly. The code will be more readable and gas efficient by just calling
the propose function:
```proposalId = IVotingMachine(votingMachine).propose(_totalOptions, ...)```
Recommendation: Replace the use of functionCall by calling the propose function of the voting
machine directly.
