### PR TITLE
removing unnecesary check on proposal calls - S1

### DIFF
--- a/contracts/dao/schemes/Scheme.sol
+++ b/contracts/dao/schemes/Scheme.sol
@@ -140,17 +140,6 @@ abstract contract Scheme is DXDVotingMachineCallbacks {
         string calldata _title,
         string calldata _descriptionHash
     ) external returns (bytes32) {
-        // Check the proposal calls
-        for (uint256 i = 0; i < _to.length; i++) {
-            bytes4 callDataFuncSignature = getFuncSignature(_callData[i]);
-
-            // This will fail only when and ERC20 transfer or approve with ETH value is proposed
-            require(
-                (callDataFuncSignature != bytes4(keccak256("transfer(address,uint256)")) &&
-                    callDataFuncSignature != bytes4(keccak256("approve(address,uint256)"))) || _value[i] == 0,
-                "WalletScheme: cant propose ERC20 transfers with value"
-            );
-        }
         require(_to.length == _callData.length, "WalletScheme: invalid _callData length");
         require(_to.length == _value.length, "WalletScheme: invalid _value length");
 


### PR DESCRIPTION
S1. Incomplete check that certain functions don’t transfer value 
On line 148, there is a check that proposed calls which target ERC20-style transfer and approve
functions cannot send ETH value with the transaction.
This check is unnecessary, because these functions are not payable in ERC20 contracts and so will
revert. For contracts that do have payable functions, the check is also easy to bypass by calling
transferFrom instead of transfer, or (if implemented) by calling increaseAllowance and
decreaseAllowance instead of approve.
Recommendation: This check (and the entire loop, lines 144 to 153) is both unnecessary and incomplete,
and so we suggest removing it.