### PR TITLE
DAOReputation: burnMuiltiple function fix

### DIFF
--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -27,11 +27,7 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     /**
      * @dev Not allow the transfer of tokens
      */
-    function _transfer(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) internal virtual override {
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual override {
         revert DAOReputation__NoTransfer();
     }
 
@@ -65,10 +61,10 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
         return true;
     }
 
-    function burnMultiple(address[] memory _accounts, uint256 _amount) external onlyOwner returns (bool) {
+    function burnMultiple(address[] memory _accounts, uint256[] memory _amount) external onlyOwner returns (bool) {
         for (uint256 i = 0; i < _accounts.length; i++) {
-            _burn(_accounts[i], _amount);
-            emit Burn(_accounts[i], _amount);
+            _burn(_accounts[i], _amount[i]);
+            emit Burn(_accounts[i], _amount[i]);
         }
         return true;
     }

--- a/test/dao/DAOReputation.js
+++ b/test/dao/DAOReputation.js
@@ -74,11 +74,7 @@ contract("DAOReputation", async accounts => {
     // Mint tokens to addresses first
     await daoReputation.mintMultiple(addresses, amounts);
     // Burn the tokens to addresses
-    const amountToBurn = 100;
-    const burnMultiple = await daoReputation.burnMultiple(
-      addresses,
-      amountToBurn
-    );
+    const burnMultiple = await daoReputation.burnMultiple(addresses, amounts);
     expect(burnMultiple, true);
 
     const reputationBalance0 = await daoReputation.balanceOf(addresses[0]);
@@ -86,7 +82,7 @@ contract("DAOReputation", async accounts => {
     const reputationBalance2 = await daoReputation.balanceOf(addresses[2]);
 
     assert.equal(reputationBalance0.toNumber(), 0);
-    assert.equal(reputationBalance1.toNumber(), 100);
-    assert.equal(reputationBalance2.toNumber(), 200);
+    assert.equal(reputationBalance1.toNumber(), 0);
+    assert.equal(reputationBalance2.toNumber(), 0);
   });
 });


### PR DESCRIPTION
### Description
Change arg `_amount` type in `burnMultiple` to be an array of uints containing the amount of rep we want to burn for each `_account` and not, on the contrary, a single unit for all accounts as it is now.