### PR TITLE
Force remove docs folder before new build

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -188,7 +188,6 @@ module.exports = {
   docgen: {
     pages: "files",
     outputDir: "docs/contracts",
-    clear: true,
     runOnCompile: false,
     exclude: ["test", "utils", "hardhat-dependency-compiler"],
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coverage": "OVERRIDE_GAS_LIMIT=0xfffffffffff OVERRIDE_GAS_PRICE=1 yarn hardhat coverage",
     "compile": "rm -rf artifacts cache contracts/hardhat-dependency-compiler && npx hardhat compile",
     "deploy": "node scripts/deploy.js",
-    "docify": "npx hardhat docgen && node ./scripts/build-docs-summary.js",
+    "docify": "rm -rf ./docs/contracts && npx hardhat docgen && node ./scripts/build-docs-summary.js",
     "solidity-linter": "./scripts/solhint.sh",
     "solidity-contract-size": "yarn hardhat size-contracts",
     "lint": "eslint .",


### PR DESCRIPTION
Force remove docs folder each time we run docgen script. Before, if we remove/rename a contract it just create a new doc file without removing the old one. 