### PR TITLE
Final v2 refactor changes

### DIFF
--- a/contracts/dao/DAOAvatar.sol
+++ b/contracts/dao/DAOAvatar.sol
@@ -9,34 +9,34 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
  */
 contract DAOAvatar is OwnableUpgradeable {
     /// @notice Emitted when the call was executed
-    event CallExecuted(address indexed _to, bytes _data, uint256 _value, bool _success);
+    event CallExecuted(address indexed to, bytes data, uint256 value, bool callSuccess, bytes callData);
 
     receive() external payable {}
 
     /**
      * @dev Initialize the avatar contract.
-     * @param _owner The address of the owner
+     * @param owner The address of the owner
      */
-    function initialize(address _owner) public initializer {
+    function initialize(address owner) public initializer {
         __Ownable_init();
-        transferOwnership(_owner);
+        transferOwnership(owner);
     }
 
     /**
      * @dev Perform a call to an arbitrary contract
-     * @param _to  The contract's address to call
-     * @param _data ABI-encoded contract call to call `_to` address.
-     * @param _value Value (ETH) to transfer with the transaction
-     * @return success Whether call was executed successfully or not
-     * @return data Call data returned
+     * @param to  The contract's address to call
+     * @param data ABI-encoded contract call to call `_to` address.
+     * @param value Value (ETH) to transfer with the transaction
+     * @return callSuccess Whether call was executed successfully or not
+     * @return callData Call data returned
      */
     function executeCall(
-        address _to,
-        bytes memory _data,
-        uint256 _value
-    ) public onlyOwner returns (bool success, bytes memory data) {
-        (success, data) = _to.call{value: _value}(_data);
-        emit CallExecuted(_to, _data, _value, success);
-        return (success, data);
+        address to,
+        bytes memory data,
+        uint256 value
+    ) public onlyOwner returns (bool callSuccess, bytes memory callData) {
+        (callSuccess, callData) = to.call{value: value}(data);
+        emit CallExecuted(to, data, value, callSuccess, callData);
+        return (callSuccess, callData);
     }
 }

--- a/contracts/dao/DAOAvatar.sol
+++ b/contracts/dao/DAOAvatar.sol
@@ -35,8 +35,8 @@ contract DAOAvatar is OwnableUpgradeable {
         bytes memory _data,
         uint256 _value
     ) public onlyOwner returns (bool success, bytes memory data) {
-        (bool success, bytes memory dataReturned) = _to.call{value: _value}(_data);
+        (success, data) = _to.call{value: _value}(_data);
         emit CallExecuted(_to, _data, _value, success);
-        return (success, dataReturned);
+        return (success, data);
     }
 }

--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -61,9 +61,6 @@ contract DAOController is Initializable {
     /// @notice Cannot unregister last scheme with manage schemes permission
     error DAOController__CannotUnregisterLastSchemeWithManageSchemesPermission();
 
-    /// @notice arg _proposalId is being used by other scheme
-    error DAOController__IdUsedByOtherScheme();
-
     /// @notice Sender is not the scheme that originally started the proposal
     error DAOController__SenderIsNotTheProposer();
 

--- a/contracts/dao/DAOController.sol
+++ b/contracts/dao/DAOController.sol
@@ -38,10 +38,10 @@ contract DAOController is Initializable {
     uint256 public schemesWithManageSchemesPermission;
 
     /// @notice Emited once scheme has been registered
-    event RegisterScheme(address indexed _sender, address indexed _scheme);
+    event RegisterScheme(address indexed sender, address indexed scheme);
 
     /// @notice Emited once scheme has been unregistered
-    event UnregisterScheme(address indexed _sender, address indexed _scheme);
+    event UnregisterScheme(address indexed sender, address indexed scheme);
 
     /// @notice Sender is not a registered scheme
     error DAOController__SenderNotRegistered();
@@ -100,82 +100,82 @@ contract DAOController is Initializable {
 
     /**
      * @dev Initialize the Controller contract.
-     * @param _scheme The address of the scheme
-     * @param _reputationToken The address of the reputation token
-     * @param _paramsHash A hashed configuration of the usage of the default scheme created on initialization
+     * @param scheme The address of the scheme
+     * @param reputationTokenAddress The address of the reputation token
+     * @param paramsHash A hashed configuration of the usage of the default scheme created on initialization
      */
     function initialize(
-        address _scheme,
-        address _reputationToken,
-        bytes32 _paramsHash
+        address scheme,
+        address reputationTokenAddress,
+        bytes32 paramsHash
     ) public initializer {
-        schemes[_scheme] = Scheme({
-            paramsHash: _paramsHash,
+        schemes[scheme] = Scheme({
+            paramsHash: paramsHash,
             isRegistered: true,
             canManageSchemes: true,
             canMakeAvatarCalls: true,
             canChangeReputation: true
         });
         schemesWithManageSchemesPermission = 1;
-        reputationToken = DAOReputation(_reputationToken);
+        reputationToken = DAOReputation(reputationTokenAddress);
     }
 
     /**
      * @dev Register a scheme
-     * @param _scheme The address of the scheme
-     * @param _paramsHash A hashed configuration of the usage of the scheme
-     * @param _canManageSchemes Whether the scheme is able to manage schemes
-     * @param _canMakeAvatarCalls Whether the scheme is able to make avatar calls
-     * @param _canChangeReputation Whether the scheme is able to change reputation
+     * @param schemeAddress The address of the scheme
+     * @param paramsHash A hashed configuration of the usage of the scheme
+     * @param canManageSchemes Whether the scheme is able to manage schemes
+     * @param canMakeAvatarCalls Whether the scheme is able to make avatar calls
+     * @param canChangeReputation Whether the scheme is able to change reputation
      * @return success Success of the operation
      */
     function registerScheme(
-        address _scheme,
-        bytes32 _paramsHash,
-        bool _canManageSchemes,
-        bool _canMakeAvatarCalls,
-        bool _canChangeReputation
+        address schemeAddress,
+        bytes32 paramsHash,
+        bool canManageSchemes,
+        bool canMakeAvatarCalls,
+        bool canChangeReputation
     ) external onlyRegisteredScheme onlyRegisteringSchemes returns (bool success) {
-        Scheme memory scheme = schemes[_scheme];
+        Scheme memory scheme = schemes[schemeAddress];
 
         // Add or change the scheme:
-        if ((!scheme.isRegistered || !scheme.canManageSchemes) && _canManageSchemes) {
+        if ((!scheme.isRegistered || !scheme.canManageSchemes) && canManageSchemes) {
             schemesWithManageSchemesPermission = schemesWithManageSchemesPermission + 1;
-        } else if (scheme.canManageSchemes && !_canManageSchemes) {
+        } else if (scheme.canManageSchemes && !canManageSchemes) {
             if (schemesWithManageSchemesPermission <= 1) {
                 revert DAOController__CannotDisableLastSchemeWithManageSchemesPermission();
             }
             schemesWithManageSchemesPermission = schemesWithManageSchemesPermission - 1;
         }
 
-        schemes[_scheme] = Scheme({
-            paramsHash: _paramsHash,
+        schemes[schemeAddress] = Scheme({
+            paramsHash: paramsHash,
             isRegistered: true,
-            canManageSchemes: _canManageSchemes,
-            canMakeAvatarCalls: _canMakeAvatarCalls,
-            canChangeReputation: _canChangeReputation
+            canManageSchemes: canManageSchemes,
+            canMakeAvatarCalls: canMakeAvatarCalls,
+            canChangeReputation: canChangeReputation
         });
 
-        emit RegisterScheme(msg.sender, _scheme);
+        emit RegisterScheme(msg.sender, schemeAddress);
 
         return true;
     }
 
     /**
      * @dev Unregister a scheme
-     * @param _scheme The address of the scheme to unregister/delete from `schemes` mapping
+     * @param schemeAddress The address of the scheme to unregister/delete from `schemes` mapping
      * @return success Success of the operation
      */
-    function unregisterScheme(address _scheme)
+    function unregisterScheme(address schemeAddress)
         external
         onlyRegisteredScheme
         onlyRegisteringSchemes
         returns (bool success)
     {
-        Scheme memory scheme = schemes[_scheme];
+        Scheme memory scheme = schemes[schemeAddress];
 
         //check if the scheme is registered
-        if (_isSchemeRegistered(_scheme) == false) {
+        if (_isSchemeRegistered(schemeAddress) == false) {
             return false;
         }
 
@@ -185,107 +185,107 @@ contract DAOController is Initializable {
             }
             schemesWithManageSchemesPermission = schemesWithManageSchemesPermission - 1;
         }
-        delete schemes[_scheme];
+        delete schemes[schemeAddress];
 
-        emit UnregisterScheme(msg.sender, _scheme);
+        emit UnregisterScheme(msg.sender, schemeAddress);
 
         return true;
     }
 
     /**
      * @dev Perform a generic call to an arbitrary contract
-     * @param _contract  The contract's address to call
-     * @param _data ABI-encoded contract call to call `_contract` address.
-     * @param _avatar The controller's avatar address
-     * @param _value Value (ETH) to transfer with the transaction
-     * @return success Whether call was executed successfully or not
-     * @return data Call data returned
+     * @param to  The contract's address to call
+     * @param data ABI-encoded contract call to call `_contract` address.
+     * @param avatar The controller's avatar address
+     * @param value Value (ETH) to transfer with the transaction
+     * @return callSuccess Whether call was executed successfully or not
+     * @return callData Call data returned
      */
     function avatarCall(
-        address _contract,
-        bytes calldata _data,
-        DAOAvatar _avatar,
-        uint256 _value
-    ) external onlyRegisteredScheme onlyAvatarCallScheme returns (bool success, bytes memory data) {
-        return _avatar.executeCall(_contract, _data, _value);
+        address to,
+        bytes calldata data,
+        DAOAvatar avatar,
+        uint256 value
+    ) external onlyRegisteredScheme onlyAvatarCallScheme returns (bool callSuccess, bytes memory callData) {
+        return avatar.executeCall(to, data, value);
     }
 
     /**
      * @dev Burns dao reputation
-     * @param _amount  The amount of reputation to burn
-     * @param _account  The account to burn reputation from
+     * @param amount  The amount of reputation to burn
+     * @param account  The account to burn reputation from
      * @return success True if the reputation are burned correctly
      */
-    function burnReputation(uint256 _amount, address _account) external onlyChangingReputation returns (bool success) {
-        return reputationToken.burn(_account, _amount);
+    function burnReputation(uint256 amount, address account) external onlyChangingReputation returns (bool success) {
+        return reputationToken.burn(account, amount);
     }
 
     /**
      * @dev Mints dao reputation
-     * @param _amount  The amount of reputation to mint
-     * @param _account  The account to mint reputation from
+     * @param amount  The amount of reputation to mint
+     * @param account  The account to mint reputation from
      * @return success True if the reputation are generated correctly
      */
-    function mintReputation(uint256 _amount, address _account) external onlyChangingReputation returns (bool success) {
-        return reputationToken.mint(_account, _amount);
+    function mintReputation(uint256 amount, address account) external onlyChangingReputation returns (bool success) {
+        return reputationToken.mint(account, amount);
     }
 
     /**
      * @dev Transfer ownership of dao reputation
-     * @param _newOwner The new owner of the reputation token
+     * @param newOwner The new owner of the reputation token
      */
-    function transferReputationOwnership(address _newOwner)
+    function transferReputationOwnership(address newOwner)
         external
         onlyRegisteringSchemes
         onlyAvatarCallScheme
         onlyChangingReputation
     {
-        reputationToken.transferOwnership(_newOwner);
+        reputationToken.transferOwnership(newOwner);
     }
 
     /**
      * @dev Returns whether a scheme is registered or not
-     * @param _scheme The address of the scheme
+     * @param scheme The address of the scheme
      * @return isRegistered Whether a scheme is registered or not
      */
-    function isSchemeRegistered(address _scheme) external view returns (bool isRegistered) {
-        return _isSchemeRegistered(_scheme);
+    function isSchemeRegistered(address scheme) external view returns (bool isRegistered) {
+        return _isSchemeRegistered(scheme);
     }
 
     /**
      * @dev Returns scheme paramsHash
-     * @param _scheme The address of the scheme
+     * @param scheme The address of the scheme
      * @return paramsHash scheme.paramsHash
      */
-    function getSchemeParameters(address _scheme) external view returns (bytes32 paramsHash) {
-        return schemes[_scheme].paramsHash;
+    function getSchemeParameters(address scheme) external view returns (bytes32 paramsHash) {
+        return schemes[scheme].paramsHash;
     }
 
     /**
      * @dev Returns if scheme can manage schemes
-     * @param _scheme The address of the scheme
+     * @param scheme The address of the scheme
      * @return canManageSchemes scheme.canManageSchemes
      */
-    function getSchemeCanManageSchemes(address _scheme) external view returns (bool canManageSchemes) {
-        return schemes[_scheme].canManageSchemes;
+    function getSchemeCanManageSchemes(address scheme) external view returns (bool canManageSchemes) {
+        return schemes[scheme].canManageSchemes;
     }
 
     /**
      * @dev Returns if scheme can make avatar calls
-     * @param _scheme The address of the scheme
+     * @param scheme The address of the scheme
      * @return canMakeAvatarCalls scheme.canMakeAvatarCalls
      */
-    function getSchemeCanMakeAvatarCalls(address _scheme) external view returns (bool canMakeAvatarCalls) {
-        return schemes[_scheme].canMakeAvatarCalls;
+    function getSchemeCanMakeAvatarCalls(address scheme) external view returns (bool canMakeAvatarCalls) {
+        return schemes[scheme].canMakeAvatarCalls;
     }
 
     /**
      * @dev Returns if scheme can change reputation
-     * @param _scheme The address of the scheme
+     * @param scheme The address of the scheme
      * @return canChangeReputation scheme.canChangeReputation
      */
-    function getSchemeCanChangeReputation(address _scheme) external view returns (bool canChangeReputation) {
-        return schemes[_scheme].canChangeReputation;
+    function getSchemeCanChangeReputation(address scheme) external view returns (bool canChangeReputation) {
+        return schemes[scheme].canChangeReputation;
     }
 
     /**
@@ -300,8 +300,8 @@ contract DAOController is Initializable {
         return schemesWithManageSchemesPermission;
     }
 
-    function _isSchemeRegistered(address _scheme) private view returns (bool) {
-        return (schemes[_scheme].isRegistered);
+    function _isSchemeRegistered(address scheme) private view returns (bool) {
+        return (schemes[scheme].isRegistered);
     }
 
     /**

--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -12,8 +12,8 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20Snapshot
  * each modification of the supply of the token (every mint an burn).
  */
 contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
-    event Mint(address indexed _to, uint256 _amount);
-    event Burn(address indexed _from, uint256 _amount);
+    event Mint(address indexed to, uint256 amount);
+    event Burn(address indexed from, uint256 amount);
 
     /// @notice Error when trying to transfer reputation
     error DAOReputation__NoTransfer();
@@ -33,65 +33,65 @@ contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     }
 
     /**
-     * @dev Generates `_amount` reputation that are assigned to `_account`
-     * @param _account The address that will be assigned the new reputation
-     * @param _amount The quantity of reputation generated
+     * @dev Generates `amount` reputation that are assigned to `account`
+     * @param account The address that will be assigned the new reputation
+     * @param amount The quantity of reputation generated
      * @return success True if the reputation are generated correctly
      */
-    function mint(address _account, uint256 _amount) external onlyOwner returns (bool success) {
-        _mint(_account, _amount);
+    function mint(address account, uint256 amount) external onlyOwner returns (bool success) {
+        _mint(account, amount);
         _snapshot();
-        emit Mint(_account, _amount);
+        emit Mint(account, amount);
         return true;
     }
 
     /**
      * @dev Mint reputation for multiple accounts
-     * @param _accounts The accounts that will be assigned the new reputation
-     * @param _amount The quantity of reputation generated for each account
+     * @param accounts The accounts that will be assigned the new reputation
+     * @param amount The quantity of reputation generated for each account
      * @return success True if the reputation are generated correctly
      */
-    function mintMultiple(address[] memory _accounts, uint256[] memory _amount)
+    function mintMultiple(address[] memory accounts, uint256[] memory amount)
         external
         onlyOwner
         returns (bool success)
     {
-        for (uint256 i = 0; i < _accounts.length; i++) {
-            _mint(_accounts[i], _amount[i]);
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _mint(accounts[i], amount[i]);
             _snapshot();
-            emit Mint(_accounts[i], _amount[i]);
+            emit Mint(accounts[i], amount[i]);
         }
         return true;
     }
 
     /**
-     * @dev Burns `_amount` reputation from `_account`
-     * @param _account The address that will lose the reputation
-     * @param _amount The quantity of reputation to burn
+     * @dev Burns ` amount` reputation from ` account`
+     * @param  account The address that will lose the reputation
+     * @param  amount The quantity of reputation to burn
      * @return success True if the reputation are burned correctly
      */
-    function burn(address _account, uint256 _amount) external onlyOwner returns (bool success) {
-        _burn(_account, _amount);
+    function burn(address account, uint256 amount) external onlyOwner returns (bool success) {
+        _burn(account, amount);
         _snapshot();
-        emit Burn(_account, _amount);
+        emit Burn(account, amount);
         return true;
     }
 
     /**
      * @dev Burn reputation from multiple accounts
-     * @param _accounts The accounts that will lose the reputation
-     * @param _amount The quantity of reputation to burn for each account
+     * @param  accounts The accounts that will lose the reputation
+     * @param  amount The quantity of reputation to burn for each account
      * @return success True if the reputation are generated correctly
      */
-    function burnMultiple(address[] memory _accounts, uint256[] memory _amount)
+    function burnMultiple(address[] memory accounts, uint256[] memory amount)
         external
         onlyOwner
         returns (bool success)
     {
-        for (uint256 i = 0; i < _accounts.length; i++) {
-            _burn(_accounts[i], _amount[i]);
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _burn(accounts[i], amount[i]);
             _snapshot();
-            emit Burn(_accounts[i], _amount[i]);
+            emit Burn(accounts[i], amount[i]);
         }
         return true;
     }

--- a/contracts/dao/schemes/AvatarScheme.sol
+++ b/contracts/dao/schemes/AvatarScheme.sol
@@ -161,7 +161,7 @@ contract AvatarScheme is Scheme {
     /**
      * @dev Get the scheme type
      */
-    function getSchemeType() external view override returns (string memory) {
+    function getSchemeType() external pure override returns (string memory) {
         return "AvatarScheme_v1";
     }
 }

--- a/contracts/dao/schemes/AvatarScheme.sol
+++ b/contracts/dao/schemes/AvatarScheme.sol
@@ -36,36 +36,36 @@ contract AvatarScheme is Scheme {
 
     /**
      * @dev Propose calls to be executed, the calls have to be allowed by the permission registry
-     * @param _to - The addresses to call
-     * @param _callData - The abi encode data for the calls
-     * @param _value value(ETH) to transfer with the calls
-     * @param _totalOptions The amount of options to be voted on
-     * @param _title title of proposal
-     * @param _descriptionHash proposal description hash
+     * @param to - The addresses to call
+     * @param callData - The abi encode data for the calls
+     * @param value value(ETH) to transfer with the calls
+     * @param totalOptions The amount of options to be voted on
+     * @param title title of proposal
+     * @param descriptionHash proposal description hash
      * @return proposalId id which represents the proposal
      */
     function proposeCalls(
-        address[] calldata _to,
-        bytes[] calldata _callData,
-        uint256[] calldata _value,
-        uint256 _totalOptions,
-        string calldata _title,
-        string calldata _descriptionHash
+        address[] calldata to,
+        bytes[] calldata callData,
+        uint256[] calldata value,
+        uint256 totalOptions,
+        string calldata title,
+        string calldata descriptionHash
     ) public override returns (bytes32 proposalId) {
-        if (_totalOptions != 2) {
+        if (totalOptions != 2) {
             revert AvatarScheme__TotalOptionsMustBeTwo();
         }
 
-        return super.proposeCalls(_to, _callData, _value, _totalOptions, _title, _descriptionHash);
+        return super.proposeCalls(to, callData, value, totalOptions, title, descriptionHash);
     }
 
     /**
      * @dev execution of proposals, can only be called by the voting machine in which the vote is held.
-     * @param _proposalId the ID of the voting in the voting machine
-     * @param _winningOption The winning option in the voting machine
+     * @param proposalId the ID of the voting in the voting machine
+     * @param winningOption The winning option in the voting machine
      * @return bool success
      */
-    function executeProposal(bytes32 _proposalId, uint256 _winningOption)
+    function executeProposal(bytes32 proposalId, uint256 winningOption)
         public
         override
         onlyVotingMachine
@@ -77,12 +77,12 @@ contract AvatarScheme is Scheme {
         }
         executingProposal = true;
 
-        Proposal memory proposal = proposals[_proposalId];
+        Proposal memory proposal = proposals[proposalId];
         if (proposal.state != ProposalState.Submitted) {
             revert AvatarScheme__ProposalMustBeSubmitted();
         }
 
-        if (_winningOption > 1) {
+        if (winningOption > 1) {
             uint256 oldRepSupply = getNativeReputationTotalSupply();
 
             controller.avatarCall(

--- a/contracts/dao/schemes/Scheme.sol
+++ b/contracts/dao/schemes/Scheme.sol
@@ -155,7 +155,7 @@ abstract contract Scheme is VotingMachineCallbacks {
         bytes32 voteParams = controller.getSchemeParameters(address(this));
 
         // Get the proposal id that will be used from the voting machine
-        bytes32 proposalId = votingMachine.propose(_totalOptions, voteParams, msg.sender, address(avatar));
+        proposalId = votingMachine.propose(_totalOptions, voteParams, msg.sender, address(avatar));
 
         // Add the proposal to the proposals mapping, proposals list and proposals information mapping
         proposals[proposalId] = Proposal({

--- a/contracts/dao/schemes/WalletScheme.sol
+++ b/contracts/dao/schemes/WalletScheme.sol
@@ -26,36 +26,36 @@ contract WalletScheme is Scheme {
 
     /**
      * @dev Propose calls to be executed, the calls have to be allowed by the permission registry
-     * @param _to - The addresses to call
-     * @param _callData - The abi encode data for the calls
-     * @param _value value(ETH) to transfer with the calls
-     * @param _totalOptions The amount of options to be voted on
-     * @param _title title of proposal
-     * @param _descriptionHash proposal description hash
+     * @param to - The addresses to call
+     * @param callData - The abi encode data for the calls
+     * @param value value(ETH) to transfer with the calls
+     * @param totalOptions The amount of options to be voted on
+     * @param title title of proposal
+     * @param descriptionHash proposal description hash
      * @return proposalId id which represents the proposal
      */
     function proposeCalls(
-        address[] calldata _to,
-        bytes[] calldata _callData,
-        uint256[] calldata _value,
-        uint256 _totalOptions,
-        string calldata _title,
-        string calldata _descriptionHash
+        address[] calldata to,
+        bytes[] calldata callData,
+        uint256[] calldata value,
+        uint256 totalOptions,
+        string calldata title,
+        string calldata descriptionHash
     ) public override returns (bytes32 proposalId) {
-        if (_totalOptions != 2) {
+        if (totalOptions != 2) {
             revert WalletScheme__TotalOptionsMustBeTwo();
         }
 
-        return super.proposeCalls(_to, _callData, _value, _totalOptions, _title, _descriptionHash);
+        return super.proposeCalls(to, callData, value, totalOptions, title, descriptionHash);
     }
 
     /**
      * @dev execution of proposals, can only be called by the voting machine in which the vote is held.
-     * @param _proposalId the ID of the voting in the voting machine
-     * @param _winningOption The winning option in the voting machine
+     * @param proposalId the ID of the voting in the voting machine
+     * @param winningOption The winning option in the voting machine
      * @return bool success
      */
-    function executeProposal(bytes32 _proposalId, uint256 _winningOption)
+    function executeProposal(bytes32 proposalId, uint256 winningOption)
         public
         override
         onlyVotingMachine
@@ -65,7 +65,7 @@ contract WalletScheme is Scheme {
             revert WalletScheme__CannotMakeAvatarCalls();
         }
 
-        return super.executeProposal(_proposalId, _winningOption);
+        return super.executeProposal(proposalId, winningOption);
     }
 
     /**

--- a/contracts/dao/schemes/WalletScheme.sol
+++ b/contracts/dao/schemes/WalletScheme.sol
@@ -71,7 +71,7 @@ contract WalletScheme is Scheme {
     /**
      * @dev Get the scheme type
      */
-    function getSchemeType() external view override returns (string memory) {
+    function getSchemeType() external pure override returns (string memory) {
         return "WalletScheme_v1";
     }
 }

--- a/contracts/dao/votingMachine/IVotingMachine.sol
+++ b/contracts/dao/votingMachine/IVotingMachine.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.17;
 interface IVotingMachine {
     function propose(
         uint256,
-        bytes32 _paramsHash,
-        address _proposer,
-        address _organization
+        bytes32 paramsHash,
+        address proposer,
+        address organization
     ) external returns (bytes32);
 }

--- a/contracts/dao/votingMachine/ProposalExecuteInterface.sol
+++ b/contracts/dao/votingMachine/ProposalExecuteInterface.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 interface ProposalExecuteInterface {
-    function executeProposal(bytes32 _proposalId, uint256 _decision) external returns (bool);
+    function executeProposal(bytes32 proposalId, uint256 winningOption) external returns (bool);
 
-    function finishProposal(bytes32 _proposalId, uint256 _decision) external returns (bool);
+    function finishProposal(bytes32 proposalId, uint256 winningOption) external returns (bool);
 }

--- a/docs/contracts/dao/DAOAvatar.md
+++ b/docs/contracts/dao/DAOAvatar.md
@@ -7,7 +7,7 @@ _The avatar, representing the DAO, owned by the DAO, controls the reputation and
 ### CallExecuted
 
 ```solidity
-event CallExecuted(address _to, bytes _data, uint256 _value, bool _success)
+event CallExecuted(address to, bytes data, uint256 value, bool callSuccess, bytes callData)
 ```
 
 Emitted when the call was executed
@@ -21,7 +21,7 @@ receive() external payable
 ### initialize
 
 ```solidity
-function initialize(address _owner) public
+function initialize(address owner) public
 ```
 
 _Initialize the avatar contract._
@@ -30,12 +30,12 @@ _Initialize the avatar contract._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _owner | address | The address of the owner |
+| owner | address | The address of the owner |
 
 ### executeCall
 
 ```solidity
-function executeCall(address _to, bytes _data, uint256 _value) public returns (bool success, bytes data)
+function executeCall(address to, bytes data, uint256 value) public returns (bool callSuccess, bytes callData)
 ```
 
 _Perform a call to an arbitrary contract_
@@ -44,14 +44,14 @@ _Perform a call to an arbitrary contract_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _to | address | The contract's address to call |
-| _data | bytes | ABI-encoded contract call to call `_to` address. |
-| _value | uint256 | Value (ETH) to transfer with the transaction |
+| to | address | The contract's address to call |
+| data | bytes | ABI-encoded contract call to call `_to` address. |
+| value | uint256 | Value (ETH) to transfer with the transaction |
 
 #### Return Values
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| success | bool | Whether call was executed successfully or not |
-| data | bytes | Call data returned |
+| callSuccess | bool | Whether call was executed successfully or not |
+| callData | bytes | Call data returned |
 

--- a/docs/contracts/dao/DAOController.md
+++ b/docs/contracts/dao/DAOController.md
@@ -60,7 +60,7 @@ uint256 schemesWithManageSchemesPermission
 ### RegisterScheme
 
 ```solidity
-event RegisterScheme(address _sender, address _scheme)
+event RegisterScheme(address sender, address scheme)
 ```
 
 Emited once scheme has been registered
@@ -68,7 +68,7 @@ Emited once scheme has been registered
 ### UnregisterScheme
 
 ```solidity
-event UnregisterScheme(address _sender, address _scheme)
+event UnregisterScheme(address sender, address scheme)
 ```
 
 Emited once scheme has been unregistered
@@ -121,14 +121,6 @@ error DAOController__CannotUnregisterLastSchemeWithManageSchemesPermission()
 
 Cannot unregister last scheme with manage schemes permission
 
-### DAOController__IdUsedByOtherScheme
-
-```solidity
-error DAOController__IdUsedByOtherScheme()
-```
-
-arg _proposalId is being used by other scheme
-
 ### DAOController__SenderIsNotTheProposer
 
 ```solidity
@@ -180,7 +172,7 @@ _Verify if scheme can change reputation_
 ### initialize
 
 ```solidity
-function initialize(address _scheme, address _reputationToken, bytes32 _paramsHash) public
+function initialize(address scheme, address reputationTokenAddress, bytes32 paramsHash) public
 ```
 
 _Initialize the Controller contract._
@@ -189,14 +181,14 @@ _Initialize the Controller contract._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
-| _reputationToken | address | The address of the reputation token |
-| _paramsHash | bytes32 | A hashed configuration of the usage of the default scheme created on initialization |
+| scheme | address | The address of the scheme |
+| reputationTokenAddress | address | The address of the reputation token |
+| paramsHash | bytes32 | A hashed configuration of the usage of the default scheme created on initialization |
 
 ### registerScheme
 
 ```solidity
-function registerScheme(address _scheme, bytes32 _paramsHash, bool _canManageSchemes, bool _canMakeAvatarCalls, bool _canChangeReputation) external returns (bool success)
+function registerScheme(address schemeAddress, bytes32 paramsHash, bool canManageSchemes, bool canMakeAvatarCalls, bool canChangeReputation) external returns (bool success)
 ```
 
 _Register a scheme_
@@ -205,11 +197,11 @@ _Register a scheme_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
-| _paramsHash | bytes32 | A hashed configuration of the usage of the scheme |
-| _canManageSchemes | bool | Whether the scheme is able to manage schemes |
-| _canMakeAvatarCalls | bool | Whether the scheme is able to make avatar calls |
-| _canChangeReputation | bool | Whether the scheme is able to change reputation |
+| schemeAddress | address | The address of the scheme |
+| paramsHash | bytes32 | A hashed configuration of the usage of the scheme |
+| canManageSchemes | bool | Whether the scheme is able to manage schemes |
+| canMakeAvatarCalls | bool | Whether the scheme is able to make avatar calls |
+| canChangeReputation | bool | Whether the scheme is able to change reputation |
 
 #### Return Values
 
@@ -220,7 +212,7 @@ _Register a scheme_
 ### unregisterScheme
 
 ```solidity
-function unregisterScheme(address _scheme) external returns (bool success)
+function unregisterScheme(address schemeAddress) external returns (bool success)
 ```
 
 _Unregister a scheme_
@@ -229,7 +221,7 @@ _Unregister a scheme_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme to unregister/delete from `schemes` mapping |
+| schemeAddress | address | The address of the scheme to unregister/delete from `schemes` mapping |
 
 #### Return Values
 
@@ -240,7 +232,7 @@ _Unregister a scheme_
 ### avatarCall
 
 ```solidity
-function avatarCall(address _contract, bytes _data, contract DAOAvatar _avatar, uint256 _value) external returns (bool success, bytes data)
+function avatarCall(address to, bytes data, contract DAOAvatar avatar, uint256 value) external returns (bool callSuccess, bytes callData)
 ```
 
 _Perform a generic call to an arbitrary contract_
@@ -249,22 +241,22 @@ _Perform a generic call to an arbitrary contract_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _contract | address | The contract's address to call |
-| _data | bytes | ABI-encoded contract call to call `_contract` address. |
-| _avatar | contract DAOAvatar | The controller's avatar address |
-| _value | uint256 | Value (ETH) to transfer with the transaction |
+| to | address | The contract's address to call |
+| data | bytes | ABI-encoded contract call to call `_contract` address. |
+| avatar | contract DAOAvatar | The controller's avatar address |
+| value | uint256 | Value (ETH) to transfer with the transaction |
 
 #### Return Values
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| success | bool | Whether call was executed successfully or not |
-| data | bytes | Call data returned |
+| callSuccess | bool | Whether call was executed successfully or not |
+| callData | bytes | Call data returned |
 
 ### burnReputation
 
 ```solidity
-function burnReputation(uint256 _amount, address _account) external returns (bool success)
+function burnReputation(uint256 amount, address account) external returns (bool success)
 ```
 
 _Burns dao reputation_
@@ -273,8 +265,8 @@ _Burns dao reputation_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _amount | uint256 | The amount of reputation to burn |
-| _account | address | The account to burn reputation from |
+| amount | uint256 | The amount of reputation to burn |
+| account | address | The account to burn reputation from |
 
 #### Return Values
 
@@ -285,7 +277,7 @@ _Burns dao reputation_
 ### mintReputation
 
 ```solidity
-function mintReputation(uint256 _amount, address _account) external returns (bool success)
+function mintReputation(uint256 amount, address account) external returns (bool success)
 ```
 
 _Mints dao reputation_
@@ -294,8 +286,8 @@ _Mints dao reputation_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _amount | uint256 | The amount of reputation to mint |
-| _account | address | The account to mint reputation from |
+| amount | uint256 | The amount of reputation to mint |
+| account | address | The account to mint reputation from |
 
 #### Return Values
 
@@ -306,7 +298,7 @@ _Mints dao reputation_
 ### transferReputationOwnership
 
 ```solidity
-function transferReputationOwnership(address _newOwner) external
+function transferReputationOwnership(address newOwner) external
 ```
 
 _Transfer ownership of dao reputation_
@@ -315,12 +307,12 @@ _Transfer ownership of dao reputation_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _newOwner | address | The new owner of the reputation token |
+| newOwner | address | The new owner of the reputation token |
 
 ### isSchemeRegistered
 
 ```solidity
-function isSchemeRegistered(address _scheme) external view returns (bool isRegistered)
+function isSchemeRegistered(address scheme) external view returns (bool isRegistered)
 ```
 
 _Returns whether a scheme is registered or not_
@@ -329,7 +321,7 @@ _Returns whether a scheme is registered or not_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
+| scheme | address | The address of the scheme |
 
 #### Return Values
 
@@ -340,7 +332,7 @@ _Returns whether a scheme is registered or not_
 ### getSchemeParameters
 
 ```solidity
-function getSchemeParameters(address _scheme) external view returns (bytes32 paramsHash)
+function getSchemeParameters(address scheme) external view returns (bytes32 paramsHash)
 ```
 
 _Returns scheme paramsHash_
@@ -349,7 +341,7 @@ _Returns scheme paramsHash_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
+| scheme | address | The address of the scheme |
 
 #### Return Values
 
@@ -360,7 +352,7 @@ _Returns scheme paramsHash_
 ### getSchemeCanManageSchemes
 
 ```solidity
-function getSchemeCanManageSchemes(address _scheme) external view returns (bool canManageSchemes)
+function getSchemeCanManageSchemes(address scheme) external view returns (bool canManageSchemes)
 ```
 
 _Returns if scheme can manage schemes_
@@ -369,7 +361,7 @@ _Returns if scheme can manage schemes_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
+| scheme | address | The address of the scheme |
 
 #### Return Values
 
@@ -380,7 +372,7 @@ _Returns if scheme can manage schemes_
 ### getSchemeCanMakeAvatarCalls
 
 ```solidity
-function getSchemeCanMakeAvatarCalls(address _scheme) external view returns (bool canMakeAvatarCalls)
+function getSchemeCanMakeAvatarCalls(address scheme) external view returns (bool canMakeAvatarCalls)
 ```
 
 _Returns if scheme can make avatar calls_
@@ -389,7 +381,7 @@ _Returns if scheme can make avatar calls_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
+| scheme | address | The address of the scheme |
 
 #### Return Values
 
@@ -400,7 +392,7 @@ _Returns if scheme can make avatar calls_
 ### getSchemeCanChangeReputation
 
 ```solidity
-function getSchemeCanChangeReputation(address _scheme) external view returns (bool canChangeReputation)
+function getSchemeCanChangeReputation(address scheme) external view returns (bool canChangeReputation)
 ```
 
 _Returns if scheme can change reputation_
@@ -409,7 +401,7 @@ _Returns if scheme can change reputation_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _scheme | address | The address of the scheme |
+| scheme | address | The address of the scheme |
 
 #### Return Values
 
@@ -434,7 +426,7 @@ _Returns the amount of schemes with manage schemes permission_
 ### _isSchemeRegistered
 
 ```solidity
-function _isSchemeRegistered(address _scheme) private view returns (bool)
+function _isSchemeRegistered(address scheme) private view returns (bool)
 ```
 
 ### getDaoReputation

--- a/docs/contracts/dao/DAOReputation.md
+++ b/docs/contracts/dao/DAOReputation.md
@@ -10,13 +10,13 @@ each modification of the supply of the token (every mint an burn)._
 ### Mint
 
 ```solidity
-event Mint(address _to, uint256 _amount)
+event Mint(address to, uint256 amount)
 ```
 
 ### Burn
 
 ```solidity
-event Burn(address _from, uint256 _amount)
+event Burn(address from, uint256 amount)
 ```
 
 ### DAOReputation__NoTransfer
@@ -44,17 +44,17 @@ _Not allow the transfer of tokens_
 ### mint
 
 ```solidity
-function mint(address _account, uint256 _amount) external returns (bool success)
+function mint(address account, uint256 amount) external returns (bool success)
 ```
 
-_Generates `_amount` reputation that are assigned to `_account`_
+_Generates `amount` reputation that are assigned to `account`_
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _account | address | The address that will be assigned the new reputation |
-| _amount | uint256 | The quantity of reputation generated |
+| account | address | The address that will be assigned the new reputation |
+| amount | uint256 | The quantity of reputation generated |
 
 #### Return Values
 
@@ -65,7 +65,7 @@ _Generates `_amount` reputation that are assigned to `_account`_
 ### mintMultiple
 
 ```solidity
-function mintMultiple(address[] _accounts, uint256[] _amount) external returns (bool success)
+function mintMultiple(address[] accounts, uint256[] amount) external returns (bool success)
 ```
 
 _Mint reputation for multiple accounts_
@@ -74,8 +74,8 @@ _Mint reputation for multiple accounts_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _accounts | address[] | The accounts that will be assigned the new reputation |
-| _amount | uint256[] | The quantity of reputation generated for each account |
+| accounts | address[] | The accounts that will be assigned the new reputation |
+| amount | uint256[] | The quantity of reputation generated for each account |
 
 #### Return Values
 
@@ -86,17 +86,17 @@ _Mint reputation for multiple accounts_
 ### burn
 
 ```solidity
-function burn(address _account, uint256 _amount) external returns (bool success)
+function burn(address account, uint256 amount) external returns (bool success)
 ```
 
-_Burns `_amount` reputation from `_account`_
+_Burns ` amount` reputation from ` account`_
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _account | address | The address that will lose the reputation |
-| _amount | uint256 | The quantity of reputation to burn |
+| account | address | The address that will lose the reputation |
+| amount | uint256 | The quantity of reputation to burn |
 
 #### Return Values
 
@@ -107,7 +107,7 @@ _Burns `_amount` reputation from `_account`_
 ### burnMultiple
 
 ```solidity
-function burnMultiple(address[] _accounts, uint256[] _amount) external returns (bool success)
+function burnMultiple(address[] accounts, uint256[] amount) external returns (bool success)
 ```
 
 _Burn reputation from multiple accounts_
@@ -116,8 +116,8 @@ _Burn reputation from multiple accounts_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _accounts | address[] | The accounts that will lose the reputation |
-| _amount | uint256[] | The quantity of reputation to burn for each account |
+| accounts | address[] | The accounts that will lose the reputation |
+| amount | uint256[] | The quantity of reputation to burn for each account |
 
 #### Return Values
 

--- a/docs/contracts/dao/schemes/AvatarScheme.md
+++ b/docs/contracts/dao/schemes/AvatarScheme.md
@@ -65,7 +65,7 @@ Emitted if the number of totalOptions is not 2
 ### proposeCalls
 
 ```solidity
-function proposeCalls(address[] _to, bytes[] _callData, uint256[] _value, uint256 _totalOptions, string _title, string _descriptionHash) public returns (bytes32 proposalId)
+function proposeCalls(address[] to, bytes[] callData, uint256[] value, uint256 totalOptions, string title, string descriptionHash) public returns (bytes32 proposalId)
 ```
 
 _Propose calls to be executed, the calls have to be allowed by the permission registry_
@@ -74,12 +74,12 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _to | address[] | - The addresses to call |
-| _callData | bytes[] | - The abi encode data for the calls |
-| _value | uint256[] | value(ETH) to transfer with the calls |
-| _totalOptions | uint256 | The amount of options to be voted on |
-| _title | string | title of proposal |
-| _descriptionHash | string | proposal description hash |
+| to | address[] | - The addresses to call |
+| callData | bytes[] | - The abi encode data for the calls |
+| value | uint256[] | value(ETH) to transfer with the calls |
+| totalOptions | uint256 | The amount of options to be voted on |
+| title | string | title of proposal |
+| descriptionHash | string | proposal description hash |
 
 #### Return Values
 
@@ -90,7 +90,7 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 ### executeProposal
 
 ```solidity
-function executeProposal(bytes32 _proposalId, uint256 _winningOption) public returns (bool)
+function executeProposal(bytes32 proposalId, uint256 winningOption) public returns (bool)
 ```
 
 _execution of proposals, can only be called by the voting machine in which the vote is held._
@@ -99,8 +99,8 @@ _execution of proposals, can only be called by the voting machine in which the v
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _proposalId | bytes32 | the ID of the voting in the voting machine |
-| _winningOption | uint256 | The winning option in the voting machine |
+| proposalId | bytes32 | the ID of the voting in the voting machine |
+| winningOption | uint256 | The winning option in the voting machine |
 
 #### Return Values
 
@@ -111,7 +111,7 @@ _execution of proposals, can only be called by the voting machine in which the v
 ### getSchemeType
 
 ```solidity
-function getSchemeType() external view returns (string)
+function getSchemeType() external pure returns (string)
 ```
 
 _Get the scheme type_

--- a/docs/contracts/dao/schemes/Scheme.md
+++ b/docs/contracts/dao/schemes/Scheme.md
@@ -89,7 +89,7 @@ Boolean that is true when is executing a proposal, to avoid re-entrancy attacks.
 ### ProposalStateChange
 
 ```solidity
-event ProposalStateChange(bytes32 _proposalId, uint256 _state)
+event ProposalStateChange(bytes32 proposalId, uint256 state)
 ```
 
 ### Scheme__CannotInitTwice
@@ -122,7 +122,7 @@ Emitted if controller address is zero
 error Scheme_InvalidParameterArrayLength()
 ```
 
-_to, _callData and _value must have all the same length
+to, callData and value must have all the same length
 
 ### Scheme__InvalidTotalOptionsOrActionsCallsLength
 
@@ -175,7 +175,7 @@ Emitted if the ERC20 limits are exceeded
 ### initialize
 
 ```solidity
-function initialize(address payable _avatar, address _votingMachine, address _controller, address _permissionRegistry, string _schemeName, uint256 _maxRepPercentageChange) external
+function initialize(address payable avatarAddress, address votingMachineAddress, address controllerAddress, address permissionRegistryAddress, string _schemeName, uint256 _maxRepPercentageChange) external
 ```
 
 _Initialize Scheme contract_
@@ -184,17 +184,17 @@ _Initialize Scheme contract_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _avatar | address payable | The avatar address |
-| _votingMachine | address | The voting machine address |
-| _controller | address | The controller address |
-| _permissionRegistry | address | The address of the permission registry contract |
+| avatarAddress | address payable | The avatar address |
+| votingMachineAddress | address | The voting machine address |
+| controllerAddress | address | The controller address |
+| permissionRegistryAddress | address | The address of the permission registry contract |
 | _schemeName | string | The name of the scheme |
 | _maxRepPercentageChange | uint256 | The maximum percentage allowed to be changed in REP total supply after proposal execution |
 
 ### proposeCalls
 
 ```solidity
-function proposeCalls(address[] _to, bytes[] _callData, uint256[] _value, uint256 _totalOptions, string _title, string _descriptionHash) public virtual returns (bytes32 proposalId)
+function proposeCalls(address[] to, bytes[] callData, uint256[] value, uint256 totalOptions, string title, string descriptionHash) public virtual returns (bytes32 proposalId)
 ```
 
 _Propose calls to be executed, the calls have to be allowed by the permission registry_
@@ -203,12 +203,12 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _to | address[] | The addresses to call |
-| _callData | bytes[] | The abi encode data for the calls |
-| _value | uint256[] | Value (ETH) to transfer with the calls |
-| _totalOptions | uint256 | The amount of options to be voted on |
-| _title | string | Title of proposal |
-| _descriptionHash | string | Proposal description hash |
+| to | address[] | The addresses to call |
+| callData | bytes[] | The abi encode data for the calls |
+| value | uint256[] | Value (ETH) to transfer with the calls |
+| totalOptions | uint256 | The amount of options to be voted on |
+| title | string | Title of proposal |
+| descriptionHash | string | Proposal description hash |
 
 #### Return Values
 
@@ -219,7 +219,7 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 ### executeProposal
 
 ```solidity
-function executeProposal(bytes32 _proposalId, uint256 _winningOption) public virtual returns (bool success)
+function executeProposal(bytes32 proposalId, uint256 winningOption) public virtual returns (bool success)
 ```
 
 _Execution of proposals, can only be called by the voting machine in which the vote is held._
@@ -228,8 +228,8 @@ _Execution of proposals, can only be called by the voting machine in which the v
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _proposalId | bytes32 | The ID of the voting in the voting machine |
-| _winningOption | uint256 | The winning option in the voting machine |
+| proposalId | bytes32 | The ID of the voting in the voting machine |
+| winningOption | uint256 | The winning option in the voting machine |
 
 #### Return Values
 
@@ -240,7 +240,7 @@ _Execution of proposals, can only be called by the voting machine in which the v
 ### finishProposal
 
 ```solidity
-function finishProposal(bytes32 _proposalId, uint256 _winningOption) public virtual returns (bool success)
+function finishProposal(bytes32 proposalId, uint256 winningOption) public virtual returns (bool success)
 ```
 
 _Finish a proposal and set the final state in storage_
@@ -249,8 +249,8 @@ _Finish a proposal and set the final state in storage_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _proposalId | bytes32 | The ID of the voting in the voting machine |
-| _winningOption | uint256 | The winning option in the voting machine |
+| proposalId | bytes32 | The ID of the voting in the voting machine |
+| winningOption | uint256 | The winning option in the voting machine |
 
 #### Return Values
 

--- a/docs/contracts/dao/schemes/WalletScheme.md
+++ b/docs/contracts/dao/schemes/WalletScheme.md
@@ -33,7 +33,7 @@ _Receive function that allows the wallet to receive ETH when the controller addr
 ### proposeCalls
 
 ```solidity
-function proposeCalls(address[] _to, bytes[] _callData, uint256[] _value, uint256 _totalOptions, string _title, string _descriptionHash) public returns (bytes32 proposalId)
+function proposeCalls(address[] to, bytes[] callData, uint256[] value, uint256 totalOptions, string title, string descriptionHash) public returns (bytes32 proposalId)
 ```
 
 _Propose calls to be executed, the calls have to be allowed by the permission registry_
@@ -42,12 +42,12 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _to | address[] | - The addresses to call |
-| _callData | bytes[] | - The abi encode data for the calls |
-| _value | uint256[] | value(ETH) to transfer with the calls |
-| _totalOptions | uint256 | The amount of options to be voted on |
-| _title | string | title of proposal |
-| _descriptionHash | string | proposal description hash |
+| to | address[] | - The addresses to call |
+| callData | bytes[] | - The abi encode data for the calls |
+| value | uint256[] | value(ETH) to transfer with the calls |
+| totalOptions | uint256 | The amount of options to be voted on |
+| title | string | title of proposal |
+| descriptionHash | string | proposal description hash |
 
 #### Return Values
 
@@ -58,7 +58,7 @@ _Propose calls to be executed, the calls have to be allowed by the permission re
 ### executeProposal
 
 ```solidity
-function executeProposal(bytes32 _proposalId, uint256 _winningOption) public returns (bool)
+function executeProposal(bytes32 proposalId, uint256 winningOption) public returns (bool)
 ```
 
 _execution of proposals, can only be called by the voting machine in which the vote is held._
@@ -67,8 +67,8 @@ _execution of proposals, can only be called by the voting machine in which the v
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _proposalId | bytes32 | the ID of the voting in the voting machine |
-| _winningOption | uint256 | The winning option in the voting machine |
+| proposalId | bytes32 | the ID of the voting in the voting machine |
+| winningOption | uint256 | The winning option in the voting machine |
 
 #### Return Values
 
@@ -79,7 +79,7 @@ _execution of proposals, can only be called by the voting machine in which the v
 ### getSchemeType
 
 ```solidity
-function getSchemeType() external view returns (string)
+function getSchemeType() external pure returns (string)
 ```
 
 _Get the scheme type_

--- a/docs/contracts/dao/votingMachine/IVotingMachine.md
+++ b/docs/contracts/dao/votingMachine/IVotingMachine.md
@@ -5,6 +5,6 @@
 ### propose
 
 ```solidity
-function propose(uint256, bytes32 _paramsHash, address _proposer, address _organization) external returns (bytes32)
+function propose(uint256, bytes32 paramsHash, address proposer, address organization) external returns (bytes32)
 ```
 

--- a/docs/contracts/dao/votingMachine/ProposalExecuteInterface.md
+++ b/docs/contracts/dao/votingMachine/ProposalExecuteInterface.md
@@ -5,12 +5,12 @@
 ### executeProposal
 
 ```solidity
-function executeProposal(bytes32 _proposalId, uint256 _decision) external returns (bool)
+function executeProposal(bytes32 proposalId, uint256 winningOption) external returns (bool)
 ```
 
 ### finishProposal
 
 ```solidity
-function finishProposal(bytes32 _proposalId, uint256 _decision) external returns (bool)
+function finishProposal(bytes32 proposalId, uint256 winningOption) external returns (bool)
 ```
 

--- a/test/dao/DAOAvatar.js
+++ b/test/dao/DAOAvatar.js
@@ -51,10 +51,10 @@ contract("DAOAvatar", function (accounts) {
     });
 
     await expectEvent(tx.receipt, "CallExecuted", {
-      _to: ANY_ADDRESS,
-      _data: callData,
-      _value: value.toString(),
-      _success: true,
+      to: ANY_ADDRESS,
+      data: callData,
+      value: value.toString(),
+      callSuccess: true,
     });
   });
 });

--- a/test/dao/DAOController.js
+++ b/test/dao/DAOController.js
@@ -280,8 +280,8 @@ contract("DAOController", function (accounts) {
 
     // A scheme can unregister another scheme
     await expectEvent(tx.receipt, "UnregisterScheme", {
-      _sender: schemeAddress,
-      _scheme: schemeToUnregister,
+      sender: schemeAddress,
+      scheme: schemeToUnregister,
     });
   });
 
@@ -358,8 +358,8 @@ contract("DAOController", function (accounts) {
     )[0];
 
     expect(avatarCallEvent.name).to.equal("CallExecuted");
-    expect(avatarCallEvent.args._to).to.equal(actionMock.address);
-    expect(avatarCallEvent.args._data).to.equal(dataCall);
+    expect(avatarCallEvent.args.to).to.equal(actionMock.address);
+    expect(avatarCallEvent.args.data).to.equal(dataCall);
   });
 
   it("burnReputation() should fail from onlyChangingReputation modifyer", async () => {

--- a/test/dao/DAOReputation.js
+++ b/test/dao/DAOReputation.js
@@ -42,8 +42,8 @@ contract("DAOReputation", async accounts => {
     const reputationBalance = await daoReputation.balanceOf(repHolder);
     expect(mint, true);
     await expectEvent(mint.receipt, "Mint", {
-      _to: repHolder,
-      _amount: amount.toString(),
+      to: repHolder,
+      amount: amount.toString(),
     });
     expect(reputationBalance.toNumber(), amount);
   });
@@ -60,8 +60,8 @@ contract("DAOReputation", async accounts => {
 
     expect(burn, true);
     await expectEvent(burn.receipt, "Burn", {
-      _from: repHolder,
-      _amount: amount.toString(),
+      from: repHolder,
+      amount: amount.toString(),
     });
     expect(reputationBalance.toNumber(), 0);
   });

--- a/test/dao/dxdao.js
+++ b/test/dao/dxdao.js
@@ -158,7 +158,7 @@ contract("DXdao", function (accounts) {
       constants.SOME_HASH
     );
 
-    proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     const activeProposals = await dxDao.votingMachine.getActiveProposals(
       0,

--- a/test/dao/schemes/AvatarScheme.js
+++ b/test/dao/schemes/AvatarScheme.js
@@ -108,7 +108,7 @@ contract("AvatarScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -139,7 +139,7 @@ contract("AvatarScheme", function (accounts) {
     );
     const proposalIdMintRep = await helpers.getValueFromLogs(
       mintRepTx,
-      "_proposalId"
+      "proposalId"
     );
     await org.votingMachine.vote(proposalIdMintRep, constants.YES_OPTION, 0, {
       from: accounts[2],
@@ -166,7 +166,7 @@ contract("AvatarScheme", function (accounts) {
     );
     const proposalIdBurnRep = await helpers.getValueFromLogs(
       burnRepTx,
-      "_proposalId"
+      "proposalId"
     );
     await org.votingMachine.vote(proposalIdBurnRep, constants.YES_OPTION, 0, {
       from: accounts[2],
@@ -242,7 +242,7 @@ contract("AvatarScheme", function (accounts) {
       constants.SOME_HASH
     );
 
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -295,7 +295,7 @@ contract("AvatarScheme", function (accounts) {
     );
     const proposalIdMintRep = await helpers.getValueFromLogs(
       mintRepTx,
-      "_proposalId"
+      "proposalId"
     );
 
     // Check inside the raw logs that the ProposalExecuteResult event logs the signature of the error to be throw
@@ -358,7 +358,7 @@ contract("AvatarScheme", function (accounts) {
     );
     const proposalIdBurnRep = await helpers.getValueFromLogs(
       burnRepTx,
-      "_proposalId"
+      "proposalId"
     );
 
     // Check inside the raw logs that the ProposalExecuteResult event logs the signature of the error to be throw

--- a/test/dao/schemes/WalletScheme.js
+++ b/test/dao/schemes/WalletScheme.js
@@ -249,7 +249,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
     await org.votingMachine.vote(proposalId1, constants.YES_OPTION, 0, {
       from: accounts[2],
@@ -389,13 +389,13 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     tx = await org.votingMachine.vote(proposalId, constants.NO_OPTION, 0, {
       from: accounts[2],
     });
     const stateChangeEvent = helpers.getEventFromTx(tx, "ProposalStateChange");
 
-    assert.equal(stateChangeEvent.args._state, 2);
+    assert.equal(stateChangeEvent.args.state, 2);
 
     const organizationProposal = await masterWalletScheme.getProposal(
       proposalId
@@ -422,7 +422,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
@@ -470,7 +470,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     // Check inside the raw logs that the ProposalExecuteResult event logs the signature of the error to be throw
     await assert(
@@ -498,7 +498,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
 
     // Use signed votes to try to execute a proposal inside a proposal execution
@@ -563,7 +563,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
 
     await expectRevert(
@@ -594,7 +594,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
     await org.votingMachine.vote(proposalId3, constants.YES_OPTION, 0, {
       from: accounts[2],
@@ -630,7 +630,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await expectEvent(
       await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
         from: accounts[2],
@@ -685,7 +685,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     await expectEvent(
       await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
@@ -716,7 +716,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     await assert(
       (
@@ -742,7 +742,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     await assert(
       (
@@ -783,7 +783,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     await expectEvent(
       await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
@@ -848,7 +848,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -876,7 +876,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId2 = await helpers.getValueFromLogs(tx2, "_proposalId");
+    const proposalId2 = await helpers.getValueFromLogs(tx2, "proposalId");
     await org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -933,7 +933,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     assert.equal(
       await web3.eth.getBalance(masterWalletScheme.address),
       constants.TEST_VALUE
@@ -980,7 +980,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     tx = await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1030,7 +1030,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdMintRep = await helpers.getValueFromLogs(
       txMintRep,
-      "_proposalId"
+      "proposalId"
     );
 
     await org.votingMachine.vote(proposalIdMintRep, constants.YES_OPTION, 0, {
@@ -1065,7 +1065,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdBurnRep = await helpers.getValueFromLogs(
       txBurnRep,
-      "_proposalId"
+      "proposalId"
     );
 
     await org.votingMachine.vote(proposalIdBurnRep, constants.YES_OPTION, 0, {
@@ -1130,7 +1130,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdMintRepToFail = await helpers.getValueFromLogs(
       failMintTx,
-      "_proposalId"
+      "proposalId"
     );
 
     await assert(
@@ -1205,7 +1205,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdBurnRepToFail = await helpers.getValueFromLogs(
       tx,
-      "_proposalId"
+      "proposalId"
     );
 
     await assert(
@@ -1258,7 +1258,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdAddScheme = await helpers.getValueFromLogs(
       tx,
-      "_proposalId"
+      "proposalId"
     );
     tx = await masterWalletScheme.proposeCalls(
       [org.controller.address],
@@ -1270,7 +1270,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdRemoveScheme = await helpers.getValueFromLogs(
       tx,
-      "_proposalId"
+      "proposalId"
     );
 
     // Add Scheme
@@ -1319,7 +1319,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.execute(proposalId);
     const organizationProposal = await masterWalletScheme.getProposal(
       proposalId
@@ -1364,7 +1364,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     assert.equal(
       await web3.eth.getBalance(masterWalletScheme.address),
       constants.TEST_VALUE
@@ -1468,12 +1468,12 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     tx = await org.votingMachine.vote(proposalId, constants.NO_OPTION, 0, {
       from: accounts[2],
     });
     const stateChangeEvent = helpers.getEventFromTx(tx, "ProposalStateChange");
-    assert.equal(stateChangeEvent.args._state, 2);
+    assert.equal(stateChangeEvent.args.state, 2);
 
     const organizationProposal = await quickWalletScheme.getProposal(
       proposalId
@@ -1499,7 +1499,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1548,7 +1548,7 @@ contract("WalletScheme", function (accounts) {
       constants.NULL_HASH
     );
     true;
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     assert.equal(
       await web3.eth.getBalance(quickWalletScheme.address),
       constants.TEST_VALUE
@@ -1591,7 +1591,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1624,7 +1624,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     tx = await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1676,7 +1676,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
-    const proposalIdMintRep = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalIdMintRep = await helpers.getValueFromLogs(tx, "proposalId");
     tx = await quickWalletScheme.proposeCalls(
       [org.controller.address],
       [callDataBurnRep],
@@ -1685,7 +1685,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
-    const proposalIdBurnRep = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalIdBurnRep = await helpers.getValueFromLogs(tx, "proposalId");
 
     // Mint Rep
     await org.votingMachine.vote(proposalIdMintRep, constants.YES_OPTION, 0, {
@@ -1742,7 +1742,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdAddScheme = await helpers.getValueFromLogs(
       tx,
-      "_proposalId"
+      "proposalId"
     );
 
     tx = await quickWalletScheme.proposeCalls(
@@ -1755,7 +1755,7 @@ contract("WalletScheme", function (accounts) {
     );
     const proposalIdRemoveScheme = await helpers.getValueFromLogs(
       tx,
-      "_proposalId"
+      "proposalId"
     );
 
     const votingTx1 = await org.votingMachine.vote(
@@ -1881,7 +1881,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1908,7 +1908,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId2 = await helpers.getValueFromLogs(tx2, "_proposalId");
+    const proposalId2 = await helpers.getValueFromLogs(tx2, "proposalId");
     await org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
@@ -1956,7 +1956,7 @@ contract("WalletScheme", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     assert.equal(
       await web3.eth.getBalance(quickWalletScheme.address),
       100000000
@@ -2040,7 +2040,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
         from: accounts[2],
       });
@@ -2070,7 +2070,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId2 = await helpers.getValueFromLogs(tx2, "_proposalId");
+      const proposalId2 = await helpers.getValueFromLogs(tx2, "proposalId");
       await org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
         from: accounts[2],
         gas: constants.GAS_LIMIT,
@@ -2132,7 +2132,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       await expectEvent(
         await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
           from: accounts[2],
@@ -2190,7 +2190,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       await expectEvent(
         await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
           from: accounts[2],
@@ -2237,7 +2237,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
         from: accounts[2],
       });
@@ -2264,7 +2264,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const proposalId2 = await helpers.getValueFromLogs(tx2, "_proposalId");
+      const proposalId2 = await helpers.getValueFromLogs(tx2, "proposalId");
 
       await org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
         from: accounts[2],
@@ -2294,7 +2294,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
 
     const reputation = await quickWalletScheme.reputationOf(
@@ -2315,7 +2315,7 @@ contract("WalletScheme", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
 
     const reputation = await quickWalletScheme.getTotalReputationSupply(

--- a/test/dao/schemes/WalletScheme.js
+++ b/test/dao/schemes/WalletScheme.js
@@ -1,6 +1,6 @@
+import { web3 } from "@openzeppelin/test-helpers/src/setup";
 import { assert } from "chai";
 import * as helpers from "../../helpers";
-const { fixSignature } = require("../../helpers/sign");
 const {
   time,
   expectRevert,
@@ -76,10 +76,18 @@ contract("WalletScheme", function (accounts) {
     );
 
     await permissionRegistry.setETHPermission(
-      org.avatar.address,
+      masterWalletScheme.address,
       constants.ZERO_ADDRESS,
       constants.NULL_SIGNATURE,
       constants.MAX_UINT_256,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      quickWalletScheme.address,
+      constants.ZERO_ADDRESS,
+      constants.NULL_SIGNATURE,
+      constants.TEST_VALUE,
       true
     );
 
@@ -97,6 +105,22 @@ contract("WalletScheme", function (accounts) {
       registrarScheme.address,
       org.controller.address,
       web3.eth.abi.encodeFunctionSignature("unregisterScheme(address)"),
+      0,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      masterWalletScheme.address,
+      org.controller.address,
+      web3.eth.abi.encodeFunctionSignature("mintReputation(uint256,address)"),
+      0,
+      true
+    );
+
+    await permissionRegistry.setETHPermission(
+      masterWalletScheme.address,
+      org.controller.address,
+      web3.eth.abi.encodeFunctionSignature("burnReputation(uint256,address)"),
       0,
       true
     );
@@ -191,15 +215,15 @@ contract("WalletScheme", function (accounts) {
       defaultParamsHash,
       false,
       false,
-      true
+      false
     );
   });
 
   it("Registrar Scheme", async function () {
     await web3.eth.sendTransaction({
-      from: accounts[0],
       to: masterWalletScheme.address,
-      value: 1000,
+      value: web3.utils.toWei("1"),
+      from: accounts[0],
     });
 
     await permissionRegistry.transferOwnership(org.avatar.address);
@@ -486,7 +510,7 @@ contract("WalletScheme", function (accounts) {
     );
   });
 
-  it.skip("MasterWalletScheme - proposal with data - positive decision - proposal executed", async function () {
+  it("MasterWalletScheme - try execute proposal within other proposal and fail", async function () {
     const callData = helpers.testCallFrom(masterWalletScheme.address);
 
     const proposalId1 = helpers.getValueFromLogs(
@@ -502,23 +526,22 @@ contract("WalletScheme", function (accounts) {
     );
 
     // Use signed votes to try to execute a proposal inside a proposal execution
-    const voteHash = await org.votingMachine.hashVote(
-      org.votingMachine.address,
+    const signerNonce = await org.votingMachine.signerNonce(accounts[3]);
+    const voteHash = await org.votingMachine.hashAction(
       proposalId1,
       accounts[2],
-      1,
-      0
+      constants.YES_OPTION,
+      0,
+      signerNonce,
+      1
     );
-    const voteSignature = fixSignature(
-      await web3.eth.sign(voteHash, accounts[2])
-    );
+    const voteSignature = await web3.eth.sign(voteHash, accounts[2]);
 
     const executeSignedVoteData = await org.votingMachine.contract.methods
       .executeSignedVote(
-        org.votingMachine.address,
         proposalId1,
         accounts[2],
-        1,
+        constants.YES_OPTION,
         0,
         voteSignature
       )
@@ -537,20 +560,6 @@ contract("WalletScheme", function (accounts) {
       .executeCall(masterWalletScheme.address, executeSignedVoteData, 0)
       .encodeABI();
 
-    // It wont allow submitting a proposal to call the wallet scheme itself, the scheme itself is only callable to call
-    // setMaxSecondsForExecution function.
-    await expectRevert(
-      masterWalletScheme.proposeCalls(
-        [masterWalletScheme.address],
-        [executeSignedVoteData],
-        [0],
-        2,
-        constants.TEST_TITLE,
-        constants.SOME_HASH
-      ),
-      "invalid proposal caller"
-    );
-
     // If we execute the proposal and we check that it succeeded it will fail because it does not allow the re execution
     // of a proposal when another is on the way, the revert will happen in the voting action when the proposal is
     // executed
@@ -566,21 +575,34 @@ contract("WalletScheme", function (accounts) {
       "proposalId"
     );
 
-    await expectRevert(
-      org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
-        from: accounts[2],
-      }),
-      "call execution failed"
-    );
+    await org.votingMachine.vote(proposalId2, constants.YES_OPTION, 0, {
+      from: accounts[2],
+    });
 
     assert.equal(
       (await masterWalletScheme.getProposal(proposalId1)).state,
       constants.WALLET_SCHEME_PROPOSAL_STATES.submitted
     );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId1)).state,
+      constants.VOTING_MACHINE_PROPOSAL_STATES.Queued
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId1)).executionState,
+      constants.VOTING_MACHINE_EXECUTION_STATES.None
+    );
 
     assert.equal(
       (await masterWalletScheme.getProposal(proposalId2)).state,
-      constants.WALLET_SCHEME_PROPOSAL_STATES.submitted
+      constants.WALLET_SCHEME_PROPOSAL_STATES.passed
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId2)).state,
+      constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInQueue
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId2)).executionState,
+      constants.VOTING_MACHINE_EXECUTION_STATES.Failed
     );
 
     // If we execute a proposal but we dont check the returned value it will still wont execute.
@@ -591,6 +613,7 @@ contract("WalletScheme", function (accounts) {
         [actionMock.address],
         [actionMockExecuteCallData],
         [0],
+        2,
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
@@ -604,10 +627,26 @@ contract("WalletScheme", function (accounts) {
       (await masterWalletScheme.getProposal(proposalId1)).state,
       constants.WALLET_SCHEME_PROPOSAL_STATES.submitted
     );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId1)).state,
+      constants.VOTING_MACHINE_PROPOSAL_STATES.Queued
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId1)).executionState,
+      constants.VOTING_MACHINE_EXECUTION_STATES.None
+    );
 
     assert.equal(
       (await masterWalletScheme.getProposal(proposalId3)).state,
       constants.WALLET_SCHEME_PROPOSAL_STATES.passed
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId3)).state,
+      constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInQueue
+    );
+    assert.equal(
+      (await org.votingMachine.proposals(proposalId3)).executionState,
+      constants.VOTING_MACHINE_EXECUTION_STATES.QueueBarCrossed
     );
   });
 
@@ -705,32 +744,6 @@ contract("WalletScheme", function (accounts) {
     );
   });
 
-  it("Global ETH transfer value not allowed value by permission registry - zero address", async function () {
-    const callData = helpers.testCallFrom(masterWalletScheme.address);
-
-    const tx = await masterWalletScheme.proposeCalls(
-      [constants.ZERO_ADDRESS],
-      [callData],
-      [101],
-      2,
-      constants.TEST_TITLE,
-      constants.SOME_HASH
-    );
-    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
-
-    await assert(
-      (
-        await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
-          from: accounts[2],
-        })
-      ).receipt.rawLogs[2].data.includes(
-        web3.eth.abi
-          .encodeParameter("string", "PermissionRegistry: Value limit reached")
-          .substring(2)
-      )
-    );
-  });
-
   it("Global ETH transfer call not allowed value by permission registry - zero address, no value", async function () {
     const callData = helpers.testCallFrom(masterWalletScheme.address);
 
@@ -760,9 +773,9 @@ contract("WalletScheme", function (accounts) {
   // eslint-disable-next-line max-len
   it("MasterWalletScheme - positive decision - proposal executed - not allowed value by permission registry in multiple calls", async function () {
     await web3.eth.sendTransaction({
-      from: accounts[0],
       to: masterWalletScheme.address,
       value: constants.TEST_VALUE,
+      from: accounts[0],
     });
 
     await permissionRegistry.setETHPermission(
@@ -893,52 +906,22 @@ contract("WalletScheme", function (accounts) {
     assert.equal(organizationProposal.value[0], 0);
   });
 
-  it.skip("MasterWalletScheme - positive decision - proposal executed with multiple calls and value", async function () {
-    var wallet = await DAOAvatar.new();
-    await wallet.initialize(masterWalletScheme.address);
-
-    await web3.eth.sendTransaction({
-      from: accounts[0],
-      to: masterWalletScheme.address,
-      value: constants.TEST_VALUE,
-    });
-
-    const payCallData = await new web3.eth.Contract(wallet.abi).methods
-      .pay(accounts[1])
+  it("MasterWalletScheme - positive decision - proposal executed with multiple calls and value", async function () {
+    const testCallData = await new web3.eth.Contract(ActionMock.abi).methods
+      .testWithNoargs()
       .encodeABI();
 
-    permissionRegistry.setETHPermission(
-      masterWalletScheme.address,
-      wallet.address,
-      constants.NULL_SIGNATURE,
-      constants.TEST_VALUE,
-      true
-    );
-
-    permissionRegistry.setETHPermission(
-      masterWalletScheme.address,
-      wallet.address,
-      payCallData.substring(0, 10),
-      constants.TEST_VALUE,
-      true
-    );
-
-    await time.increase(30);
-
     const tx = await masterWalletScheme.proposeCalls(
-      [wallet.address, wallet.address],
-      ["0x0", payCallData],
+      [accounts[1], actionMock.address],
+      ["0x0", testCallData],
       [constants.TEST_VALUE, 0],
       2,
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
     const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
-    assert.equal(
-      await web3.eth.getBalance(masterWalletScheme.address),
-      constants.TEST_VALUE
-    );
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     const balanceBeforePay = await web3.eth.getBalance(accounts[1]);
 
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
@@ -946,7 +929,7 @@ contract("WalletScheme", function (accounts) {
       gas: 9000000,
     });
     assert.equal(await web3.eth.getBalance(masterWalletScheme.address), 0);
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     assert.equal(
       await web3.eth.getBalance(accounts[1]),
       Number(balanceBeforePay) + constants.TEST_VALUE
@@ -960,50 +943,11 @@ contract("WalletScheme", function (accounts) {
       constants.WALLET_SCHEME_PROPOSAL_STATES.passed
     );
     assert.equal(organizationProposal.callData[0], "0x00");
-    assert.equal(organizationProposal.to[0], wallet.address);
+    assert.equal(organizationProposal.to[0], accounts[1]);
     assert.equal(organizationProposal.value[0], constants.TEST_VALUE);
-    assert.equal(organizationProposal.callData[1], payCallData);
-    assert.equal(organizationProposal.to[1], wallet.address);
+    assert.equal(organizationProposal.callData[1], testCallData);
+    assert.equal(organizationProposal.to[1], actionMock.address);
     assert.equal(organizationProposal.value[1], 0);
-  });
-
-  it.skip("MasterWalletScheme - positive decision - proposal executed without return value", async function () {
-    const callData = helpers.testCallWithoutReturnValueFrom(
-      masterWalletScheme.address
-    );
-
-    let tx = await masterWalletScheme.proposeCalls(
-      [actionMock.address],
-      [callData],
-      [0],
-      2,
-      constants.TEST_TITLE,
-      constants.SOME_HASH
-    );
-    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
-    tx = await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
-      from: accounts[2],
-    });
-
-    // ! There is no event called "ExecutionResults"
-    const executionEvent = helpers.getEventFromTx(tx, "ExecutionResults");
-    const returnValue = web3.eth.abi.decodeParameters(
-      ["bool", "bytes"],
-      executionEvent.args._callsDataResult[0]
-    );
-    assert.equal(returnValue["0"], true);
-    assert.equal(returnValue["1"], null);
-
-    const organizationProposal = await masterWalletScheme.getProposal(
-      proposalId
-    );
-    assert.equal(
-      organizationProposal.state,
-      constants.WALLET_SCHEME_PROPOSAL_STATES.passed
-    );
-    assert.equal(organizationProposal.callData[0], callData);
-    assert.equal(organizationProposal.to[0], actionMock.address);
-    assert.equal(organizationProposal.value[0], 0);
   });
 
   it("MasterWalletScheme - proposal with REP - execute mintReputation & burnReputation", async function () {
@@ -1011,14 +955,6 @@ contract("WalletScheme", function (accounts) {
     const callDataMintRep = await org.controller.contract.methods
       .mintReputation(constants.TEST_VALUE, accounts[4])
       .encodeABI();
-
-    await permissionRegistry.setETHPermission(
-      masterWalletScheme.address,
-      org.controller.address,
-      callDataMintRep.substring(0, 10),
-      0,
-      true
-    );
 
     const txMintRep = await masterWalletScheme.proposeCalls(
       [org.controller.address],
@@ -1046,14 +982,6 @@ contract("WalletScheme", function (accounts) {
     const callDataBurnRep = await org.controller.contract.methods
       .burnReputation(constants.TEST_VALUE, accounts[4])
       .encodeABI();
-
-    await permissionRegistry.setETHPermission(
-      masterWalletScheme.address,
-      org.controller.address,
-      callDataBurnRep.substring(0, 10),
-      0,
-      true
-    );
 
     const txBurnRep = await masterWalletScheme.proposeCalls(
       [org.controller.address],
@@ -1330,46 +1258,29 @@ contract("WalletScheme", function (accounts) {
     );
   });
 
-  it.skip("MasterWalletScheme - positive decision - proposal executed with transfer, pay and mint rep", async function () {
-    var wallet = await Wallet.new();
+  it("MasterWalletScheme - positive decision - proposal executed with transfer, pay and mint rep", async function () {
     await web3.eth.sendTransaction({
-      from: accounts[0],
       to: masterWalletScheme.address,
       value: constants.TEST_VALUE,
+      from: accounts[0],
     });
-    await wallet.transferOwnership(masterWalletScheme.address);
 
-    const payCallData = await new web3.eth.Contract(wallet.abi).methods
-      .pay(accounts[1])
-      .encodeABI();
-
+    const testCallData = helpers.testCallFrom(masterWalletScheme.address);
     const callDataMintRep = await org.controller.contract.methods
-      .mintReputation(constants.TEST_VALUE, accounts[4], org.avatar.address)
+      .mintReputation(constants.TEST_VALUE, accounts[4])
       .encodeABI();
-
-    await permissionRegistry.setETHPermission(
-      masterWalletScheme.address,
-      wallet.address,
-      payCallData.substring(0, 10),
-      constants.TEST_VALUE,
-      true
-    );
-
-    await time.increase(100);
 
     const tx = await masterWalletScheme.proposeCalls(
-      [wallet.address, wallet.address, org.controller.address],
-      ["0x0", payCallData, callDataMintRep],
+      [accounts[1], actionMock.address, org.controller.address],
+      ["0x0", testCallData, callDataMintRep],
       [constants.TEST_VALUE, 0, 0],
+      2,
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
     const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
-    assert.equal(
-      await web3.eth.getBalance(masterWalletScheme.address),
-      constants.TEST_VALUE
-    );
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     assert.equal(await org.reputation.balanceOf(accounts[4]), 0);
 
     const balanceBeforePay = await web3.eth.getBalance(accounts[1]);
@@ -1377,7 +1288,7 @@ contract("WalletScheme", function (accounts) {
       from: accounts[2],
     });
     assert.equal(await web3.eth.getBalance(masterWalletScheme.address), 0);
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     assert.equal(
       await web3.eth.getBalance(accounts[1]),
       Number(balanceBeforePay) + constants.TEST_VALUE
@@ -1396,10 +1307,10 @@ contract("WalletScheme", function (accounts) {
     );
     assert.equal(organizationProposal.descriptionHash, constants.SOME_HASH);
     assert.equal(organizationProposal.callData[0], "0x00");
-    assert.equal(organizationProposal.to[0], wallet.address);
+    assert.equal(organizationProposal.to[0], accounts[1]);
     assert.equal(organizationProposal.value[0], constants.TEST_VALUE);
-    assert.equal(organizationProposal.callData[1], payCallData);
-    assert.equal(organizationProposal.to[1], wallet.address);
+    assert.equal(organizationProposal.callData[1], testCallData);
+    assert.equal(organizationProposal.to[1], actionMock.address);
     assert.equal(organizationProposal.value[1], 0);
     assert.equal(organizationProposal.callData[2], callDataMintRep);
     assert.equal(organizationProposal.to[2], org.controller.address);
@@ -1517,49 +1428,30 @@ contract("WalletScheme", function (accounts) {
   });
 
   // eslint-disable-next-line max-len
-  it.skip("QuickWalletScheme - proposal with data - positive decision - proposal executed with multiple calls and value", async function () {
-    var wallet = await Wallet.new();
+  it("QuickWalletScheme - proposal with data - positive decision - proposal executed with multiple calls and value", async function () {
     await web3.eth.sendTransaction({
-      from: accounts[0],
       to: quickWalletScheme.address,
       value: constants.TEST_VALUE,
+      from: accounts[0],
     });
-    await wallet.transferOwnership(quickWalletScheme.address);
-
-    const payCallData = await new web3.eth.Contract(wallet.abi).methods
-      .pay(accounts[1])
-      .encodeABI();
-
-    await permissionRegistry.setETHPermission(
-      quickWalletScheme.address,
-      wallet.address,
-      payCallData.substring(0, 10),
-      constants.TEST_VALUE,
-      true
-    );
-    await time.increase(100);
-
+    const testCallData = helpers.testCallFrom(quickWalletScheme.address);
     const tx = await quickWalletScheme.proposeCalls(
-      [wallet.address, wallet.address],
-      ["0x0", payCallData],
-      [constants.TEST_VALUE],
+      [accounts[1], actionMock.address],
+      ["0x0", testCallData],
+      [constants.TEST_VALUE, 0],
       2,
       constants.TEST_TITLE,
       constants.NULL_HASH
     );
-    true;
     const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
-    assert.equal(
-      await web3.eth.getBalance(quickWalletScheme.address),
-      constants.TEST_VALUE
-    );
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     const balanceBeforePay = await web3.eth.getBalance(accounts[1]);
     await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
     assert.equal(await web3.eth.getBalance(quickWalletScheme.address), 0);
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     assert.equal(
       await web3.eth.getBalance(accounts[1]),
       Number(balanceBeforePay) + constants.TEST_VALUE
@@ -1573,11 +1465,11 @@ contract("WalletScheme", function (accounts) {
       constants.WALLET_SCHEME_PROPOSAL_STATES.passed
     );
     assert.equal(organizationProposal.callData[0], "0x00");
-    assert.equal(organizationProposal.to[0], wallet.address);
+    assert.equal(organizationProposal.to[0], accounts[1]);
     assert.equal(organizationProposal.value[0], constants.TEST_VALUE);
-    assert.equal(organizationProposal.callData[1], payCallData);
-    assert.equal(organizationProposal.to[1], wallet.address);
+    assert.equal(organizationProposal.to[1], actionMock.address);
     assert.equal(organizationProposal.value[1], 0);
+    assert.equal(organizationProposal.callData[1], testCallData);
   });
 
   it("QuickWalletScheme - proposal with data - positive decision - proposal execution fail", async () => {
@@ -1611,7 +1503,7 @@ contract("WalletScheme", function (accounts) {
   });
 
   // eslint-disable-next-line max-len
-  it.skip("QuickWalletScheme - proposal with data - positive decision - proposal executed without return value", async function () {
+  it("QuickWalletScheme - proposal with data - positive decision - proposal executed without return value", async function () {
     const callData = helpers.testCallWithoutReturnValueFrom(
       quickWalletScheme.address
     );
@@ -1619,7 +1511,7 @@ contract("WalletScheme", function (accounts) {
     let tx = await quickWalletScheme.proposeCalls(
       [actionMock.address],
       [callData],
-      [0, 0],
+      [0],
       2,
       constants.TEST_TITLE,
       constants.SOME_HASH
@@ -1628,11 +1520,6 @@ contract("WalletScheme", function (accounts) {
     tx = await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
-    const executionEvent = helpers.getEventFromTx(tx, "ExecutionResults");
-
-    const returnValues = executionEvent.args._callsDataResult[0];
-    assert.equal(returnValues, "0x");
-
     const organizationProposal = await quickWalletScheme.getProposal(
       proposalId
     );
@@ -1645,12 +1532,12 @@ contract("WalletScheme", function (accounts) {
     assert.equal(organizationProposal.value[0], 0);
   });
 
-  it("QuickWalletScheme - proposal with REP - execute mintReputation & burnReputation", async function () {
+  it("QuickWalletScheme - proposal with REP - execute mintReputation & burnReputation should fail", async function () {
     const callDataMintRep = await org.controller.contract.methods
       .mintReputation(constants.TEST_VALUE, accounts[4])
       .encodeABI();
     const callDataBurnRep = await org.controller.contract.methods
-      .burnReputation(constants.TEST_VALUE, accounts[4])
+      .burnReputation(constants.TEST_VALUE, accounts[1])
       .encodeABI();
 
     await permissionRegistry.setETHPermission(
@@ -1691,16 +1578,13 @@ contract("WalletScheme", function (accounts) {
     await org.votingMachine.vote(proposalIdMintRep, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
-    assert.equal(
-      await org.reputation.balanceOf(accounts[4]),
-      constants.TEST_VALUE
-    );
+    assert.equal(await org.reputation.balanceOf(accounts[4]), 0);
 
     // Burn Rep
     await org.votingMachine.vote(proposalIdBurnRep, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
-    assert.equal(await org.reputation.balanceOf(accounts[4]), 0);
+    assert.equal(await org.reputation.balanceOf(accounts[1]), 10000);
   });
 
   // eslint-disable-next-line max-len
@@ -1925,71 +1809,41 @@ contract("WalletScheme", function (accounts) {
     assert.equal(organizationProposal.value[0], 0);
   });
 
-  it.skip("QuickWalletScheme - positive decision - proposal executed with transfer, pay and mint rep", async function () {
-    var wallet = await WalletScheme.new();
+  it("QuickWalletScheme - positive decision - proposal executed with transfer and pay", async function () {
     await web3.eth.sendTransaction({
-      from: accounts[0],
       to: quickWalletScheme.address,
-      value: 100000000,
+      value: constants.TEST_VALUE,
+      from: accounts[0],
     });
-    // await wallet.transferOwnership(quickWalletScheme.address);
 
-    const payCallData = await new web3.eth.Contract(wallet.abi).methods
-      .pay(accounts[1])
-      .encodeABI();
-    const callDataMintRep = await org.controller.contract.methods
-      .mintReputation(constants.TEST_VALUE, accounts[4], org.avatar.address)
-      .encodeABI();
-
-    await permissionRegistry.setETHPermission(
-      quickWalletScheme.address,
-      wallet.address,
-      payCallData.substring(0, 10),
-      constants.TEST_VALUE,
-      true
-    );
+    const testCallData = helpers.testCallFrom(quickWalletScheme.address);
 
     let tx = await quickWalletScheme.proposeCalls(
-      [wallet.address, wallet.address, org.controller.address],
-      ["0x0", payCallData, callDataMintRep],
-      [constants.TEST_VALUE, 0, 0],
+      [accounts[1], actionMock.address],
+      ["0x0", testCallData],
+      [constants.TEST_VALUE, 0],
+      2,
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
     const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
     assert.equal(
       await web3.eth.getBalance(quickWalletScheme.address),
-      100000000
+      constants.TEST_VALUE
     );
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
-    assert.equal(await org.reputation.balanceOf(accounts[4]), 0);
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
 
     const balanceBeforePay = await web3.eth.getBalance(accounts[1]);
     tx = await org.votingMachine.vote(proposalId, constants.YES_OPTION, 0, {
       from: accounts[2],
     });
-    const executionEvent = helpers.getEventFromTx(tx, "ExecutionResults");
-    assert.equal(executionEvent.args._callsSucessResult[0], true);
-    assert.equal(executionEvent.args._callsSucessResult[1], true);
-    assert.equal(executionEvent.args._callsSucessResult[2], true);
-    assert.equal(executionEvent.args._callsDataResult[0], "0x");
-    assert.equal(executionEvent.args._callsDataResult[1], "0x");
-    assert.equal(
-      executionEvent.args._callsDataResult[2],
-      "0x0000000000000000000000000000000000000000000000000000000000000001"
-    );
 
     assert.equal(await web3.eth.getBalance(masterWalletScheme.address), 0);
-    assert.equal(await web3.eth.getBalance(wallet.address), 0);
+    assert.equal(await web3.eth.getBalance(actionMock.address), 0);
     assert.equal(
       await web3.eth.getBalance(accounts[1]),
       Number(balanceBeforePay) + constants.TEST_VALUE
     );
-    assert.equal(
-      await org.reputation.balanceOf(accounts[4]),
-      constants.TEST_VALUE
-    );
-
     const organizationProposal = await quickWalletScheme.getProposal(
       proposalId
     );
@@ -1998,14 +1852,11 @@ contract("WalletScheme", function (accounts) {
       constants.WALLET_SCHEME_PROPOSAL_STATES.passed
     );
     assert.equal(organizationProposal.callData[0], "0x00");
-    assert.equal(organizationProposal.to[0], wallet.address);
+    assert.equal(organizationProposal.to[0], accounts[1]);
     assert.equal(organizationProposal.value[0], constants.TEST_VALUE);
-    assert.equal(organizationProposal.callData[1], payCallData);
-    assert.equal(organizationProposal.to[1], wallet.address);
+    assert.equal(organizationProposal.callData[1], testCallData);
+    assert.equal(organizationProposal.to[1], actionMock.address);
     assert.equal(organizationProposal.value[1], 0);
-    assert.equal(organizationProposal.callData[2], callDataMintRep);
-    assert.equal(organizationProposal.to[2], org.controller.address);
-    assert.equal(organizationProposal.value[2], 0);
   });
 
   describe("ERC20 Transfers", async function () {

--- a/test/dao/votingMachines/VotingMachine.js
+++ b/test/dao/votingMachines/VotingMachine.js
@@ -202,6 +202,7 @@ contract("VotingMachine", function (accounts) {
       ERC20Mock.abi.find(x => x.name === "approve"),
       [dxdVotingMachine.address, web3.utils.toWei("100")]
     );
+
     const proposalToApproveStakeTokens = await helpers.getValueFromLogs(
       await masterAvatarScheme.proposeCalls(
         [stakingToken.address],
@@ -400,7 +401,7 @@ contract("VotingMachine", function (accounts) {
       });
 
       it("Can view rep of votes and amount staked on proposal", async function () {
-        const statusInfo = await dxdVotingMachine.proposalStatus(
+        const statusInfo = await dxdVotingMachine.getProposalStatus(
           setRefundConfProposalId
         );
 
@@ -437,11 +438,11 @@ contract("VotingMachine", function (accounts) {
         );
 
         await expectEvent(vote.receipt, "VoteProposal", {
-          _proposalId: proposalId,
-          _avatar: org.avatar.address,
-          _voter: accounts[1],
-          _vote: constants.YES_OPTION.toString(),
-          _reputation: "10000",
+          proposalId: proposalId,
+          avatar: org.avatar.address,
+          voter: accounts[1],
+          option: constants.YES_OPTION.toString(),
+          reputation: "10000",
         });
 
         const secondVote = await dxdVotingMachine.vote(
@@ -620,7 +621,7 @@ contract("VotingMachine", function (accounts) {
         expectEvent(voteTx, "ActionSigned", {
           proposalId: proposalId,
           voter: accounts[3],
-          voteDecision: constants.YES_OPTION,
+          option: constants.YES_OPTION,
           amount: "70000",
           nonce: signerNonce,
           signature: votesignature,
@@ -704,7 +705,7 @@ contract("VotingMachine", function (accounts) {
           dxdVotingMachine.executeSignedVote(
             voteInfoFromLog.proposalId,
             voteInfoFromLog.voter,
-            voteInfoFromLog.voteDecision,
+            voteInfoFromLog.option,
             voteInfoFromLog.amount - 1,
             voteInfoFromLog.signature,
             { from: accounts[4] }
@@ -716,7 +717,7 @@ contract("VotingMachine", function (accounts) {
           dxdVotingMachine.executeSignedVote(
             voteInfoFromLog.proposalId,
             accounts[1],
-            voteInfoFromLog.voteDecision,
+            voteInfoFromLog.option,
             voteInfoFromLog.amount,
             voteInfoFromLog.signature,
             { from: accounts[4] }
@@ -755,7 +756,7 @@ contract("VotingMachine", function (accounts) {
         await dxdVotingMachine.executeSignedVote(
           voteInfoFromLog.proposalId,
           voteInfoFromLog.voter,
-          voteInfoFromLog.voteDecision,
+          voteInfoFromLog.option,
           voteInfoFromLog.amount,
           voteInfoFromLog.signature,
           { from: accounts[4] }
@@ -818,7 +819,7 @@ contract("VotingMachine", function (accounts) {
       it("positive signal decision", async function () {
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           0
         );
         await expectRevert(
@@ -835,7 +836,7 @@ contract("VotingMachine", function (accounts) {
         );
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           constants.YES_OPTION
         );
         assert.equal(
@@ -852,7 +853,7 @@ contract("VotingMachine", function (accounts) {
         );
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           0
         );
         const schemeProposal = await masterAvatarScheme.getProposal(proposalId);
@@ -865,7 +866,7 @@ contract("VotingMachine", function (accounts) {
       it("negative signal decision", async function () {
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           0
         );
         const signalVoteTx = await dxdVotingMachine.signalVote(
@@ -876,7 +877,7 @@ contract("VotingMachine", function (accounts) {
         );
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           constants.NO_OPTION
         );
         assert.equal(
@@ -894,7 +895,7 @@ contract("VotingMachine", function (accounts) {
         );
         assert.equal(
           (await dxdVotingMachine.votesSignaled(proposalId, accounts[3]))
-            .voteDecision,
+            .option,
           0
         );
         const schemeProposal = await masterAvatarScheme.getProposal(proposalId);
@@ -932,8 +933,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(stakeTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await dxdVotingMachine.vote(testProposalId, constants.YES_OPTION, 0, {
@@ -956,8 +957,8 @@ contract("VotingMachine", function (accounts) {
         dxdVotingMachine.contract,
         "StateChange",
         {
-          _proposalId: testProposalId,
-          _proposalState:
+          proposalId: testProposalId,
+          proposalState:
             constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
         }
       );
@@ -1018,8 +1019,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(stakeTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await dxdVotingMachine.vote(testProposalId, constants.YES_OPTION, 0, {
@@ -1042,8 +1043,8 @@ contract("VotingMachine", function (accounts) {
         dxdVotingMachine.contract,
         "StateChange",
         {
-          _proposalId: testProposalId,
-          _proposalState:
+          proposalId: testProposalId,
+          proposalState:
             constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
         }
       );
@@ -1173,8 +1174,8 @@ contract("VotingMachine", function (accounts) {
       // attack ends
 
       expectEvent(stakeTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await dxdVotingMachine.vote(testProposalId, constants.YES_OPTION, 0, {
@@ -1196,8 +1197,8 @@ contract("VotingMachine", function (accounts) {
         dxdVotingMachine.contract,
         "StateChange",
         {
-          _proposalId: testProposalId,
-          _proposalState:
+          proposalId: testProposalId,
+          proposalState:
             constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
         }
       );
@@ -1244,8 +1245,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(stakeTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await dxdVotingMachine.vote(testProposalId, constants.YES_OPTION, 1, {
@@ -1265,8 +1266,8 @@ contract("VotingMachine", function (accounts) {
         dxdVotingMachine.contract,
         "StateChange",
         {
-          _proposalId: testProposalId,
-          _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.Expired,
+          proposalId: testProposalId,
+          proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.Expired,
         }
       );
 
@@ -1319,8 +1320,8 @@ contract("VotingMachine", function (accounts) {
 
       // check preBoosted
       expectEvent(upStake.receipt, "StateChange", {
-        _proposalId: proposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: proposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       // vote enough times to pass the execution bar threshold
@@ -1389,8 +1390,8 @@ contract("VotingMachine", function (accounts) {
 
       // check preBoosted
       expectEvent(upStake.receipt, "StateChange", {
-        _proposalId: proposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: proposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await time.increase(
@@ -1473,8 +1474,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(stake.receipt, "StateChange", {
-        _proposalId: stakeProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: stakeProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await time.increase(
@@ -1504,9 +1505,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(executeStake.receipt, "StateChange", {
-        _proposalId: stakeProposalId,
-        _proposalState:
-          constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
+        proposalId: stakeProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
       });
 
       expectEvent.notEmitted(executeStake.receipt, "Stake");
@@ -1522,11 +1522,11 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(upStake.receipt, "Stake", {
-        _proposalId: stakeProposalId,
-        _avatar: org.avatar.address,
-        _staker: accounts[1],
-        _vote: constants.YES_OPTION.toString(),
-        _amount: "100",
+        proposalId: stakeProposalId,
+        avatar: org.avatar.address,
+        staker: accounts[1],
+        option: constants.YES_OPTION.toString(),
+        amount: "100",
       });
 
       const downStake = await dxdVotingMachine.stake(
@@ -1580,8 +1580,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(stakeTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.PreBoosted,
       });
 
       await time.increase(
@@ -1599,8 +1599,8 @@ contract("VotingMachine", function (accounts) {
       );
 
       expectEvent(voteTx.receipt, "StateChange", {
-        _proposalId: testProposalId,
-        _proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.Boosted,
+        proposalId: testProposalId,
+        proposalState: constants.VOTING_MACHINE_PROPOSAL_STATES.Boosted,
       });
 
       await time.increase(helpers.defaultParameters.boostedVotePeriodLimit + 1);
@@ -1615,8 +1615,8 @@ contract("VotingMachine", function (accounts) {
         dxdVotingMachine.contract,
         "StateChange",
         {
-          _proposalId: testProposalId,
-          _proposalState:
+          proposalId: testProposalId,
+          proposalState:
             constants.VOTING_MACHINE_PROPOSAL_STATES.ExecutedInBoost,
         }
       );
@@ -1709,10 +1709,8 @@ contract("VotingMachine", function (accounts) {
       const paramsHash = (await dxdVotingMachine.proposals(testProposalId1))
         .paramsHash;
       const schemeParameters = await dxdVotingMachine.parameters(paramsHash);
-      const threshold0BoostedProposal = await dxdVotingMachine.threshold(
-        paramsHash,
-        schemeId
-      );
+      const threshold0BoostedProposal =
+        await dxdVotingMachine.getSchemeThreshold(paramsHash, schemeId);
       const stakesToBoostFirstProposal =
         await dxdVotingMachine.multiplyRealMath(
           threshold0BoostedProposal,
@@ -1944,9 +1942,10 @@ contract("VotingMachine", function (accounts) {
 
       // Downstake on the proposal to get it back to queue
       const stakesToUnBoostSecondProposal = (
-        await dxdVotingMachine.proposalStatus(testProposalId2)
+        await dxdVotingMachine.getProposalStatus(testProposalId2)
       ).totalStakesYes.sub(
-        (await dxdVotingMachine.proposalStatus(testProposalId2)).totalStakesNo
+        (await dxdVotingMachine.getProposalStatus(testProposalId2))
+          .totalStakesNo
       );
       await dxdVotingMachine.stake(
         testProposalId2,
@@ -2021,34 +2020,9 @@ contract("VotingMachine", function (accounts) {
         from: accounts[1],
       });
 
-      const voteInfo = await dxdVotingMachine.voteInfo(proposalId, accounts[1]);
+      const voteInfo = await dxdVotingMachine.getVoter(proposalId, accounts[1]);
       assert.equal(constants.YES_OPTION, Number(voteInfo[0]));
       assert.equal(10000, Number(voteInfo[1]));
-    });
-
-    it("should return vote status", async function () {
-      const proposalId = await helpers.getValueFromLogs(
-        await masterAvatarScheme.proposeCalls(
-          [actionMock.address],
-          [helpers.testCallFrom(org.avatar.address)],
-          [0],
-          2,
-          constants.TEST_TITLE,
-          constants.SOME_HASH
-        ),
-        "_proposalId"
-      );
-
-      await dxdVotingMachine.vote(proposalId, constants.YES_OPTION, 0, {
-        from: accounts[1],
-      });
-
-      const voteStatus = await dxdVotingMachine.voteStatus(
-        proposalId,
-        constants.YES_OPTION
-      );
-
-      assert.equal(10000, Number(voteStatus));
     });
 
     it("should return true if the proposal is votable", async function () {

--- a/test/dao/votingMachines/VotingMachine.js
+++ b/test/dao/votingMachines/VotingMachine.js
@@ -43,7 +43,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         );
-        return helpers.getValueFromLogs(tx, "_proposalId");
+        return helpers.getValueFromLogs(tx, "proposalId");
       })
     );
 
@@ -212,7 +212,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       ),
-      "_proposalId"
+      "proposalId"
     );
     await dxdVotingMachine.vote(
       proposalToApproveStakeTokens,
@@ -266,7 +266,7 @@ contract("VotingMachine", function (accounts) {
         );
         setRefundConfProposalId = await helpers.getValueFromLogs(
           setRefundConfTx,
-          "_proposalId"
+          "proposalId"
         );
         const schemeId = (
           await dxdVotingMachine.proposals(setRefundConfProposalId)
@@ -313,7 +313,7 @@ contract("VotingMachine", function (accounts) {
         );
         const fundVotingMachineProposalId = await helpers.getValueFromLogs(
           fundVotingMachineTx,
-          "_proposalId"
+          "proposalId"
         );
         const schemeId = (
           await dxdVotingMachine.proposals(setRefundConfProposalId)
@@ -341,7 +341,7 @@ contract("VotingMachine", function (accounts) {
           constants.SOME_HASH
         );
 
-        let proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+        let proposalId = await helpers.getValueFromLogs(tx, "proposalId");
         assert.equal(
           TOTAL_GAS_REFUND_PER_VOTE * 2,
           Number((await dxdVotingMachine.schemes(schemeId)).voteGasBalance)
@@ -425,7 +425,7 @@ contract("VotingMachine", function (accounts) {
             constants.TEST_TITLE,
             constants.SOME_HASH
           ),
-          "_proposalId"
+          "proposalId"
         );
 
         const vote = await dxdVotingMachine.vote(
@@ -500,7 +500,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         );
-        proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+        proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       });
 
       it("fail sharing invalid vote signature", async function () {
@@ -813,7 +813,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         );
-        proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+        proposalId = await helpers.getValueFromLogs(tx, "proposalId");
       });
 
       it("positive signal decision", async function () {
@@ -917,7 +917,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const testProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const testProposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
       const stakesToBoost = await dxdVotingMachine.calculateBoostChange(
         testProposalId
@@ -988,7 +988,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const testProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const testProposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
       const stakesToBoost = await dxdVotingMachine.calculateBoostChange(
         testProposalId
@@ -1059,7 +1059,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const testProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const testProposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
       assert.equal(await stakingToken.balanceOf(dxdVotingMachine.address), "0");
 
@@ -1143,7 +1143,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       await dxdVotingMachine.stake(
         fakeProposalId,
@@ -1230,7 +1230,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const testProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const testProposalId = await helpers.getValueFromLogs(tx, "proposalId");
       const stakesToBoost = await dxdVotingMachine.calculateBoostChange(
         testProposalId
       );
@@ -1297,7 +1297,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       const stakesToBoost = await dxdVotingMachine.calculateBoostChange(
@@ -1367,7 +1367,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       const stakesToBoost = await dxdVotingMachine.calculateBoostChange(
@@ -1455,7 +1455,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
     });
 
@@ -1552,7 +1552,7 @@ contract("VotingMachine", function (accounts) {
         constants.TEST_TITLE,
         constants.SOME_HASH
       );
-      const testProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+      const testProposalId = await helpers.getValueFromLogs(tx, "proposalId");
       const testProposal = await dxdVotingMachine.proposals(testProposalId);
 
       const signerNonce = await dxdVotingMachine.signerNonce(accounts[1]);
@@ -1658,7 +1658,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId2 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1669,7 +1669,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId3 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1680,7 +1680,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId4 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1691,7 +1691,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId5 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1702,7 +1702,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const schemeId = (await dxdVotingMachine.proposals(testProposalId1))
         .schemeId;
@@ -1851,7 +1851,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId2 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1862,7 +1862,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
       const testProposalId3 = await helpers.getValueFromLogs(
         await masterAvatarScheme.proposeCalls(
@@ -1873,7 +1873,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       const paramsHash = (await dxdVotingMachine.proposals(testProposalId1))
@@ -2013,7 +2013,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       await dxdVotingMachine.vote(proposalId, constants.YES_OPTION, 0, {
@@ -2035,7 +2035,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       const isVotable = await dxdVotingMachine.isVotable(proposalId);
@@ -2052,7 +2052,7 @@ contract("VotingMachine", function (accounts) {
           constants.TEST_TITLE,
           constants.SOME_HASH
         ),
-        "_proposalId"
+        "proposalId"
       );
 
       await dxdVotingMachine.vote(proposalId, constants.YES_OPTION, 0, {

--- a/test/erc20guild/implementations/DXDGuild.js
+++ b/test/erc20guild/implementations/DXDGuild.js
@@ -129,7 +129,7 @@ contract("DXDGuild", function (accounts) {
       "Test Title",
       constants.SOME_HASH
     );
-    walletSchemeProposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    walletSchemeProposalId = await helpers.getValueFromLogs(tx, "proposalId");
   });
 
   describe("DXDGuild", function () {

--- a/test/utils/PermissionRegistry.js
+++ b/test/utils/PermissionRegistry.js
@@ -131,7 +131,7 @@ contract("PermissionRegistry", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId1 = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId1 = await helpers.getValueFromLogs(tx, "proposalId");
 
     assert.equal(
       (
@@ -177,7 +177,7 @@ contract("PermissionRegistry", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId2 = await helpers.getValueFromLogs(tx2, "_proposalId");
+    const proposalId2 = await helpers.getValueFromLogs(tx2, "proposalId");
 
     // The call to execute is not allowed YET, because we change the delay time to 45 seconds
     await expectEvent(
@@ -199,7 +199,7 @@ contract("PermissionRegistry", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId3 = await helpers.getValueFromLogs(tx4, "_proposalId");
+    const proposalId3 = await helpers.getValueFromLogs(tx4, "proposalId");
 
     // The call to execute is not allowed YET, because we change the delay time to 45 seconds
     await dao.votingMachine.vote(proposalId3, constants.YES_OPTION, 0, {
@@ -257,7 +257,7 @@ contract("PermissionRegistry", function (accounts) {
       constants.TEST_TITLE,
       constants.SOME_HASH
     );
-    const proposalId = await helpers.getValueFromLogs(tx, "_proposalId");
+    const proposalId = await helpers.getValueFromLogs(tx, "proposalId");
 
     assert.notEqual(
       (


### PR DESCRIPTION
- Remove `_` used for variable names, leaving the _ to be used only for internal functions.
- Change decision for options, using options to refer as vote options. Proposal -> Options (NO< YES) -> Calls
- Rename some variables to avoid shadow variable name declaration.
- Fix almost all compiler warnings.