### PR TITLE
Use same ERC20SnapshotRep for dao and guilds

### DIFF
--- a/contracts/dao/DAOReputation.sol
+++ b/contracts/dao/DAOReputation.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.17;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "../utils/ERC20/ERC20SnapshotRep.sol";
 
 /**
  * @title DAO Reputation
@@ -11,93 +10,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20Snapshot
  * It uses a snapshot mechanism to keep track of the reputation at the moment of
  * each modification of the supply of the token (every mint an burn).
  */
-contract DAOReputation is OwnableUpgradeable, ERC20SnapshotUpgradeable {
-    event Mint(address indexed to, uint256 amount);
-    event Burn(address indexed from, uint256 amount);
+contract DAOReputation is ERC20SnapshotRep {
 
-    /// @notice Error when trying to transfer reputation
-    error DAOReputation__NoTransfer();
-
-    function initialize(string memory name, string memory symbol) external initializer {
-        __ERC20_init(name, symbol);
-        __Ownable_init();
-    }
-
-    /// @dev Not allow the transfer of tokens
-    function _transfer(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) internal virtual override {
-        revert DAOReputation__NoTransfer();
-    }
-
-    /**
-     * @dev Generates `amount` reputation that are assigned to `account`
-     * @param account The address that will be assigned the new reputation
-     * @param amount The quantity of reputation generated
-     * @return success True if the reputation are generated correctly
-     */
-    function mint(address account, uint256 amount) external onlyOwner returns (bool success) {
-        _mint(account, amount);
-        _snapshot();
-        emit Mint(account, amount);
-        return true;
-    }
-
-    /**
-     * @dev Mint reputation for multiple accounts
-     * @param accounts The accounts that will be assigned the new reputation
-     * @param amount The quantity of reputation generated for each account
-     * @return success True if the reputation are generated correctly
-     */
-    function mintMultiple(address[] memory accounts, uint256[] memory amount)
-        external
-        onlyOwner
-        returns (bool success)
-    {
-        for (uint256 i = 0; i < accounts.length; i++) {
-            _mint(accounts[i], amount[i]);
-            _snapshot();
-            emit Mint(accounts[i], amount[i]);
-        }
-        return true;
-    }
-
-    /**
-     * @dev Burns ` amount` reputation from ` account`
-     * @param  account The address that will lose the reputation
-     * @param  amount The quantity of reputation to burn
-     * @return success True if the reputation are burned correctly
-     */
-    function burn(address account, uint256 amount) external onlyOwner returns (bool success) {
-        _burn(account, amount);
-        _snapshot();
-        emit Burn(account, amount);
-        return true;
-    }
-
-    /**
-     * @dev Burn reputation from multiple accounts
-     * @param  accounts The accounts that will lose the reputation
-     * @param  amount The quantity of reputation to burn for each account
-     * @return success True if the reputation are generated correctly
-     */
-    function burnMultiple(address[] memory accounts, uint256[] memory amount)
-        external
-        onlyOwner
-        returns (bool success)
-    {
-        for (uint256 i = 0; i < accounts.length; i++) {
-            _burn(accounts[i], amount[i]);
-            _snapshot();
-            emit Burn(accounts[i], amount[i]);
-        }
-        return true;
-    }
-
-    /// @dev Get the current snapshotId
-    function getCurrentSnapshotId() public view returns (uint256) {
-        return _getCurrentSnapshotId();
-    }
 }

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
@@ -12,7 +11,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
  * each modification of the supply of the token (every mint an burn).
  * It also keeps track of the total holders of the token.
  */
-contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
+contract ERC20SnapshotRep is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     // @dev total holders of tokens
     uint256 public totalHolders;
 

--- a/contracts/utils/ERC20/ERC20SnapshotRep.sol
+++ b/contracts/utils/ERC20/ERC20SnapshotRep.sol
@@ -4,63 +4,121 @@ pragma solidity ^0.8.17;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
 /**
  * @title ERC20SnapshotRep
+ * @dev An ERC20 token that is non-transferable and is mintable and burnable only by the owner.
+ * It uses a snapshot mechanism to keep track of the reputation at the moment of
+ * each modification of the supply of the token (every mint an burn).
+ * It also keeps track of the total holders of the token.
  */
 contract ERC20SnapshotRep is Initializable, OwnableUpgradeable, ERC20SnapshotUpgradeable {
-    using SafeMathUpgradeable for uint256;
-
-    // @dev total holders of Rep tokens
+    // @dev total holders of tokens
     uint256 public totalHolders;
+
+    event Mint(address indexed to, uint256 amount);
+    event Burn(address indexed from, uint256 amount);
+
+    /// @notice Error when trying to transfer reputation
+    error ERC20SnapshotRep__NoTransfer();
 
     function initialize(string memory name, string memory symbol) external initializer {
         __ERC20_init(name, symbol);
         __Ownable_init();
     }
 
-    function snapshot() external {
+    /// @dev Not allow the transfer of tokens
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        revert ERC20SnapshotRep__NoTransfer();
+    }
+
+    function _addHolder(address account) internal {
+        if (balanceOf(account) == 0) totalHolders++;
+    }
+
+    function _removeHolder(address account) internal {
+        if (balanceOf(account) == 0 && totalHolders > 0) totalHolders--;
+    }
+
+    /**
+     * @dev Generates `amount` reputation that are assigned to `account`
+     * @param account The address that will be assigned the new reputation
+     * @param amount The quantity of reputation generated
+     * @return success True if the reputation are generated correctly
+     */
+    function mint(address account, uint256 amount) external onlyOwner returns (bool success) {
+        _addHolder(account);
+        _mint(account, amount);
         _snapshot();
+        emit Mint(account, amount);
+        return true;
     }
 
-    function getCurrentSnapshotId() external view virtual returns (uint256) {
-        return _getCurrentSnapshotId();
+    /**
+     * @dev Mint reputation for multiple accounts
+     * @param accounts The accounts that will be assigned the new reputation
+     * @param amount The quantity of reputation generated for each account
+     * @return success True if the reputation are generated correctly
+     */
+    function mintMultiple(address[] memory accounts, uint256[] memory amount)
+        external
+        onlyOwner
+        returns (bool success)
+    {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _addHolder(accounts[i]);
+            _mint(accounts[i], amount[i]);
+            _snapshot();
+            emit Mint(accounts[i], amount[i]);
+        }
+        return true;
     }
 
-    function getTotalHolders() external view returns (uint256) {
+    /**
+     * @dev Burns ` amount` reputation from ` account`
+     * @param  account The address that will lose the reputation
+     * @param  amount The quantity of reputation to burn
+     * @return success True if the reputation are burned correctly
+     */
+    function burn(address account, uint256 amount) external onlyOwner returns (bool success) {
+        _burn(account, amount);
+        _removeHolder(account);
+        _snapshot();
+        emit Burn(account, amount);
+        return true;
+    }
+
+    /**
+     * @dev Burn reputation from multiple accounts
+     * @param  accounts The accounts that will lose the reputation
+     * @param  amount The quantity of reputation to burn for each account
+     * @return success True if the reputation are generated correctly
+     */
+    function burnMultiple(address[] memory accounts, uint256[] memory amount)
+        external
+        onlyOwner
+        returns (bool success)
+    {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _burn(accounts[i], amount[i]);
+            _removeHolder(accounts[i]);
+            _snapshot();
+            emit Burn(accounts[i], amount[i]);
+        }
+        return true;
+    }
+
+    /// @dev Get the total holders amount
+    function getTotalHolders() public view returns (uint256) {
         return totalHolders;
     }
 
-    function addHolder(address account) internal returns (bool) {
-        if (balanceOf(account) == 0) {
-            totalHolders = totalHolders.add(1);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function removeHolder(address account) internal returns (bool) {
-        if (balanceOf(account) == 0 && totalHolders > 0) {
-            totalHolders = totalHolders.sub(1);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function mint(address to, uint256 amount) external virtual onlyOwner {
-        // @dev we only add to the totalHolders if they did not have tokens prior to minting
-        addHolder(to);
-        _mint(to, amount);
-        _snapshot();
-    }
-
-    function burn(address to, uint256 amount) external virtual onlyOwner {
-        _burn(to, amount);
-        // @dev we only remove from the totalHolders if they do not have tokens after burning
-        removeHolder(to);
-        _snapshot();
+    /// @dev Get the current snapshotId
+    function getCurrentSnapshotId() public view returns (uint256) {
+        return _getCurrentSnapshotId();
     }
 }

--- a/test/dao/DAOReputation.js
+++ b/test/dao/DAOReputation.js
@@ -34,6 +34,16 @@ contract("DAOReputation", async accounts => {
     );
   });
 
+  it("should not be able to transferFrom tokens", async () => {
+    await daoReputation.approve(accounts[1], 100, { from: accounts[0] });
+    await expectRevert(
+      daoReputation.transferFrom(accounts[0], accounts[2], 1, {
+        from: accounts[1],
+      }),
+      "ERC20SnapshotRep__NoTransfer()"
+    );
+  });
+
   it("should mint rep tokens", async () => {
     const repHolder = accounts[0];
     const amount = 100;

--- a/test/dao/DAOReputation.js
+++ b/test/dao/DAOReputation.js
@@ -30,7 +30,7 @@ contract("DAOReputation", async accounts => {
   it("should not be able to transfer tokens", async () => {
     await expectRevert(
       daoReputation.transfer(accounts[1], 100),
-      "DAOReputation__NoTransfer()"
+      "ERC20SnapshotRep__NoTransfer()"
     );
   });
 

--- a/test/utils/ERC20/ERC20SnapshotRep.js
+++ b/test/utils/ERC20/ERC20SnapshotRep.js
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import { artifacts, contract } from "hardhat";
+const { expectRevert } = require("@openzeppelin/test-helpers");
 
 const ERC20SnapshotRep = artifacts.require("ERC20SnapshotRep.sol");
 
@@ -12,6 +13,25 @@ contract("ERC20SnapshotRep", accounts => {
     });
     await ERC20SnapshotRepToken.initialize("DXdao", "DXD");
     await ERC20SnapshotRepToken.mint(accounts[1], 100, { from: accounts[0] });
+  });
+
+  it("should not be able to transfer tokens", async () => {
+    assert.equal(await ERC20SnapshotRepToken.balanceOf(accounts[1]), "100");
+    await expectRevert(
+      ERC20SnapshotRepToken.transfer(accounts[2], 1, { from: accounts[1] }),
+      "ERC20SnapshotRep__NoTransfer()"
+    );
+  });
+
+  it("should not be able to transferFrom tokens", async () => {
+    assert.equal(await ERC20SnapshotRepToken.balanceOf(accounts[1]), "100");
+    await ERC20SnapshotRepToken.approve(accounts[2], 100, {
+      from: accounts[1],
+    });
+    await expectRevert(
+      ERC20SnapshotRepToken.transfer(accounts[3], 1, { from: accounts[2] }),
+      "ERC20SnapshotRep__NoTransfer()"
+    );
   });
 
   describe("snapshot balances", () => {


### PR DESCRIPTION
This PR moves the code form the DAOReputation to the ERC20SnapshotRep token contract, the main idea here is to inherit the ERC20SnapshotRep token by the DAOReputation and have it included as audited code, and also being used by the ERC20GuildSnapshotRep contract.