### PR TITLE
fix: erc20 limit check underflow

### DIFF
--- a/contracts/test/ERC20Mock.sol
+++ b/contracts/test/ERC20Mock.sol
@@ -10,9 +10,13 @@ contract ERC20Mock is ERC20PresetFixedSupply {
         string memory symbol,
         uint256 initialBalance,
         address initialAccount
-    ) public ERC20PresetFixedSupply(name, symbol, initialBalance, initialAccount) {}
+    ) ERC20PresetFixedSupply(name, symbol, initialBalance, initialAccount) {}
 
     function nonStandardTransfer(address recipient, uint256 amount) public returns (bool success) {
         return transfer(recipient, amount);
+    }
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
     }
 }

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -231,14 +231,17 @@ contract PermissionRegistry is OwnableUpgradeable {
      * @dev Checks the value transferred in block for all registered ERC20 limits.
      * @param from The address from which ERC20 tokens limits will be checked
      */
-    function checkERC20Limits(address from) public returns (bool) {
+    function checkERC20Limits(address from) public view returns (bool) {
         require(erc20LimitsOnBlock[from] == block.number, "PermissionRegistry: ERC20 initialValues not set");
         for (uint256 i = 0; i < erc20Limits[from].length; i++) {
-            require(
-                erc20Limits[from][i].initialValueOnBlock.sub(IERC20(erc20Limits[from][i].token).balanceOf(from)) <=
-                    erc20Limits[from][i].valueAllowed,
-                "PermissionRegistry: Value limit reached"
-            );
+            uint256 currentBalance = IERC20(erc20Limits[from][i].token).balanceOf(from);
+            if (currentBalance < erc20Limits[from][i].initialValueOnBlock) {
+                require(
+                    erc20Limits[from][i].initialValueOnBlock.sub(currentBalance) <=
+                        erc20Limits[from][i].valueAllowed,
+                    "PermissionRegistry: Value limit reached"
+                );
+            }
         }
         return true;
     }


### PR DESCRIPTION
When ERC20 tokens that have transfer limits are sent to the guild (instead of out of it) during a proposal execution, an underflow occurs in `checkERC20Limits()` and the execution fails.