### PR TITLE
refactor: allow gas refunds for contracts

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -455,7 +455,7 @@ contract BaseERC20Guild {
         if (voteGas > 0) {
             uint256 gasRefund = voteGas * tx.gasprice.min(maxGasPrice);
 
-            if (address(this).balance >= gasRefund && !address(msg.sender).isContract()) {
+            if (address(this).balance >= gasRefund) {
                 (bool success, ) = payable(msg.sender).call{value: gasRefund}("");
                 require(success, "Failed to refund gas");
             }

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -219,7 +219,7 @@ contract("ERC20Guild", function (accounts) {
     await time.increase(30);
     await erc20Guild.endProposal(setETHPermissionToActionMockA);
   };
-if (false) {
+
   describe("initialization", function () {
     it("initial values are correct", async function () {
       assert.equal(await erc20Guild.getToken(), guildToken.address);
@@ -2062,7 +2062,7 @@ if (false) {
       assert.equal(withdrawEvent.args[1], 50000);
     });
   });
-}
+
   describe("refund votes", function () {
     beforeEach(async function () {
       await lockTokens();
@@ -2375,7 +2375,7 @@ if (false) {
       }
     });
   });
-if (false) {
+
   describe("Signed votes", function () {
     beforeEach(async function () {
       const tokenVault = await erc20Guild.getTokenVault();
@@ -2571,5 +2571,4 @@ if (false) {
       );
     });
   });
-}
 });


### PR DESCRIPTION
Gas refunds are only allowed when using an EOA to vote. This is enforced using an [isContract() check](https://github.com/DXgovernance/dxdao-contracts/blob/54410e27dc25bb580d5fb99b60509b0d38889098/contracts/erc20guild/BaseERC20Guild.sol#L481) before refunding. However, isContract() returns false if msg.sender is a contract in construction.

If isContract() was a counter-measure against reentrancy, it achieves nothing, although I don't see how reentrancy could do any harm in this case. If this is the case, I suggest removing it.

If isContract() was meant to cap refunds when batching signature votes or similar, I'm not sure what is the need for that, but it could be fooled using a contract in construction.