### PR TITLE
fix: execute erc20 limit removal after delay

### DIFF
--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -12,7 +12,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * permissions sent by that address.
  * The PermissionRegistry owner (if there is an owner and owner address is not 0x0) can overwrite/set any permission.
  * The registry allows setting ERC20 limits, the limit needs to be set at the beggining of the block and then it can be
- * checked at any time. To remove or replace ERC20 limits first it needs to be removed and then it can be set again.
+ * checked at any time.
  * The smart contracts permissions are compound by the `from` address, `to` address, `value` uint256 and `fromTime` uint256,
  * if `fromTime` is zero it means the function is not allowed.
  */
@@ -138,8 +138,8 @@ contract PermissionRegistry is OwnableUpgradeable {
     }
 
     /**
-     * @dev Removes an ERC20 limit of an address by its index in the ERC20Lmits array.
-     * (take in count that the limit execution has to be called after the remove time)
+     * @dev Updates an ERC20 limit of an address by its index in the ERC20Lmits array.
+     * (take in count that the limit execution has to be called after the update time)
      * @param from The address that will execute the call
      * @param index The index of the token permission in the erco limits
      * @param newValueAllowed The index of the token permission in the erco limits

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -161,7 +161,7 @@ contract PermissionRegistry is OwnableUpgradeable {
      */
     function executeRemoveERC20Limit(address from, uint256 index) public {
         require(
-            block.timestamp < erc20Limits[from][index].removeTime,
+            block.timestamp > erc20Limits[from][index].removeTime,
             "PermissionRegistry: Cant execute permission removal"
         );
 

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -33,10 +33,10 @@ contract PermissionRegistry is OwnableUpgradeable {
 
     struct ERC20Limit {
         address token;
-        uint96 updateTime;
         uint256 initialValueOnBlock;
         uint256 valueAllowed;
         uint256 pendingValueAllowed;
+        uint256 updateTime;
     }
 
     // from address => to address => function call signature allowed => Permission
@@ -150,8 +150,7 @@ contract PermissionRegistry is OwnableUpgradeable {
         }
         require(index < erc20Limits[from].length, "PermissionRegistry: Index out of bounds");
 
-        uint96 delay = permissionDelay[from] > type(uint96).max ? type(uint96).max : uint96(permissionDelay[from]);
-        erc20Limits[from][index].updateTime = uint96(block.timestamp.add(delay));
+        erc20Limits[from][index].updateTime = block.timestamp.add(permissionDelay[from]);
         erc20Limits[from][index].pendingValueAllowed = newValueAllowed;
     }
 

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -160,8 +160,9 @@ contract PermissionRegistry is OwnableUpgradeable {
      * @param index The index of the token permission in the erco limits
      */
     function executeRemoveERC20Limit(address from, uint256 index) public {
+        uint256 removeTime = erc20Limits[from][index].removeTime;
         require(
-            block.timestamp > erc20Limits[from][index].removeTime,
+            removeTime != 0 && block.timestamp > removeTime,
             "PermissionRegistry: Cant execute permission removal"
         );
 
@@ -220,6 +221,7 @@ contract PermissionRegistry is OwnableUpgradeable {
         if (erc20LimitsOnBlock[msg.sender] < block.number) {
             erc20LimitsOnBlock[msg.sender] = block.number;
             for (uint256 i = 0; i < erc20Limits[msg.sender].length; i++) {
+                if (erc20Limits[msg.sender][i].token == address(0x0)) continue;
                 erc20Limits[msg.sender][i].initialValueOnBlock = IERC20(erc20Limits[msg.sender][i].token).balanceOf(
                     msg.sender
                 );
@@ -234,6 +236,7 @@ contract PermissionRegistry is OwnableUpgradeable {
     function checkERC20Limits(address from) public view returns (bool) {
         require(erc20LimitsOnBlock[from] == block.number, "PermissionRegistry: ERC20 initialValues not set");
         for (uint256 i = 0; i < erc20Limits[from].length; i++) {
+            if (erc20Limits[from][i].token == address(0x0)) continue;
             uint256 currentBalance = IERC20(erc20Limits[from][i].token).balanceOf(from);
             if (currentBalance < erc20Limits[from][i].initialValueOnBlock) {
                 require(

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -117,13 +117,13 @@ contract PermissionRegistry is OwnableUpgradeable {
         if (msg.sender != owner()) {
             require(from == msg.sender, "PermissionRegistry: Only owner can specify from value");
         }
-        uint256 totalLimits = erc20Limits[from].length;
-        require(index <= totalLimits, "PermissionRegistry: Index out of bounds");
+        uint256 erc20LimitLength = erc20Limits[from].length;
+        require(index <= erc20LimitLength, "PermissionRegistry: Index out of bounds");
         require(token != address(0), "PermissionRegistry: Token address cannot be 0x0");
-        for (uint256 i = 0; i < totalLimits; i++) {
+        for (uint256 i = 0; i < erc20LimitLength; i++) {
             require(erc20Limits[from][i].token != token, "PermissionRegistry: Limit on token already added");
         }
-        if (index == totalLimits) {
+        if (index == erc20LimitLength) {
             erc20Limits[from].push();
         } else {
             require(

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -161,10 +161,7 @@ contract PermissionRegistry is OwnableUpgradeable {
      */
     function executeRemoveERC20Limit(address from, uint256 index) public {
         uint256 removeTime = erc20Limits[from][index].removeTime;
-        require(
-            removeTime != 0 && block.timestamp > removeTime,
-            "PermissionRegistry: Cant execute permission removal"
-        );
+        require(removeTime != 0 && block.timestamp > removeTime, "PermissionRegistry: Cant execute permission removal");
 
         erc20Limits[from][index] = ERC20Limit(address(0), 0, 0, 0);
     }
@@ -240,8 +237,7 @@ contract PermissionRegistry is OwnableUpgradeable {
             uint256 currentBalance = IERC20(erc20Limits[from][i].token).balanceOf(from);
             if (currentBalance < erc20Limits[from][i].initialValueOnBlock) {
                 require(
-                    erc20Limits[from][i].initialValueOnBlock.sub(currentBalance) <=
-                        erc20Limits[from][i].valueAllowed,
+                    erc20Limits[from][i].initialValueOnBlock.sub(currentBalance) <= erc20Limits[from][i].valueAllowed,
                     "PermissionRegistry: Value limit reached"
                 );
             }

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -162,7 +162,7 @@ contract PermissionRegistry is OwnableUpgradeable {
      */
     function executeUpdateERC20Limit(address from, uint256 index) public {
         uint256 updateTime = erc20Limits[from][index].updateTime;
-        require(updateTime != 0 && block.timestamp > updateTime, "PermissionRegistry: Cant execute permission removal");
+        require(updateTime != 0 && block.timestamp > updateTime, "PermissionRegistry: Cant execute permission update");
 
         uint256 newValueAllowed = erc20Limits[from][index].pendingValueAllowed;
         if (newValueAllowed == 0) {

--- a/contracts/utils/PermissionRegistry.sol
+++ b/contracts/utils/PermissionRegistry.sol
@@ -123,11 +123,14 @@ contract PermissionRegistry is OwnableUpgradeable {
         for (uint256 i = 0; i < totalLimits; i++) {
             require(erc20Limits[from][i].token != token, "PermissionRegistry: Limit on token already added");
         }
-        if (index == totalLimits) erc20Limits[from].push();
-        require(
-            erc20Limits[from][index].token == address(0),
-            "PermissionRegistry: Cant override existent ERC20 limit"
-        );
+        if (index == totalLimits) {
+            erc20Limits[from].push();
+        } else {
+            require(
+                erc20Limits[from][index].token == address(0),
+                "PermissionRegistry: Cant override existent ERC20 limit"
+            );
+        }
         
         erc20Limits[from][index].token = token;
         erc20Limits[from][index].valueAllowed = valueAllowed;
@@ -153,8 +156,8 @@ contract PermissionRegistry is OwnableUpgradeable {
     }
 
     /**
-     * @dev Executes the final removal of an ERC20 limit of an address by its index in the ERC20Lmits array.
-     * @param from The address that will execute the call
+     * @dev Executes the final update of an ERC20 limit of an address by its index in the ERC20Lmits array.
+     * @param from The address from which ERC20 tokens limits will be updated
      * @param index The index of the token permission in the erco limits
      */
     function executeUpdateERC20Limit(address from, uint256 index) public {
@@ -168,12 +171,6 @@ contract PermissionRegistry is OwnableUpgradeable {
             erc20Limits[from][index].updateTime = 0;
             erc20Limits[from][index].valueAllowed = newValueAllowed;
             erc20Limits[from][index].pendingValueAllowed = 0;
-            // From this moment on during this block, negative balance changes for this token are not allowed.
-            uint256 currentBalance = IERC20(erc20Limits[from][index].token).balanceOf(from);
-            unchecked {
-                uint256 x = currentBalance + newValueAllowed;
-                erc20Limits[from][index].initialValueOnBlock = x >= currentBalance ? x : type(uint256).max;
-            }
         }
     }
 

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -219,7 +219,7 @@ contract("ERC20Guild", function (accounts) {
     await time.increase(30);
     await erc20Guild.endProposal(setETHPermissionToActionMockA);
   };
-if (false) {
+
   describe("initialization", function () {
     it("initial values are correct", async function () {
       assert.equal(await erc20Guild.getToken(), guildToken.address);
@@ -1293,7 +1293,7 @@ if (false) {
       assert.equal(state, constants.WALLET_SCHEME_PROPOSAL_STATES.passed);
     });
   });
-}
+
   describe("permission registry checks", function () {
     let testToken;
 
@@ -1339,9 +1339,7 @@ if (false) {
                 .setETHPermission(
                   erc20Guild.address,
                   testToken.address,
-                  web3.eth.abi.encodeFunctionSignature(
-                    "mint(address,uint256)"
-                  ),
+                  web3.eth.abi.encodeFunctionSignature("mint(address,uint256)"),
                   0,
                   true
                 )
@@ -1549,7 +1547,11 @@ if (false) {
         guild: erc20Guild,
         options: [
           {
-            to: [permissionRegistry.address, testToken.address, testToken.address],
+            to: [
+              permissionRegistry.address,
+              testToken.address,
+              testToken.address,
+            ],
             data: [
               await new web3.eth.Contract(PermissionRegistry.abi).methods
                 .removeERC20Limit(erc20Guild.address, 0)
@@ -1749,7 +1751,7 @@ if (false) {
         proposalId: guildProposalId,
         newState: "3",
       });
-      
+
       // ERC20 transfer limits are no longer checked after removal execution
       guildProposalId = await createProposal({
         guild: erc20Guild,
@@ -1985,7 +1987,7 @@ if (false) {
       );
     });
   });
-if (false) {
+
   describe("complete proposal process", function () {
     beforeEach(async function () {
       await lockTokens();
@@ -2773,5 +2775,4 @@ if (false) {
       );
     });
   });
-}
 });

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1554,7 +1554,7 @@ contract("ERC20Guild", function (accounts) {
             ],
             data: [
               await new web3.eth.Contract(PermissionRegistry.abi).methods
-                .removeERC20Limit(erc20Guild.address, 0)
+                .updateERC20Limit(erc20Guild.address, 0, 0)
                 .encodeABI(),
               await new web3.eth.Contract(ERC20Mock.abi).methods
                 .transfer(accounts[2], 100)
@@ -1603,10 +1603,10 @@ contract("ERC20Guild", function (accounts) {
             to: [permissionRegistry.address, permissionRegistry.address],
             data: [
               await new web3.eth.Contract(PermissionRegistry.abi).methods
-                .removeERC20Limit(erc20Guild.address, 0)
+                .updateERC20Limit(erc20Guild.address, 0, 0)
                 .encodeABI(),
               await new web3.eth.Contract(PermissionRegistry.abi).methods
-                .executeRemoveERC20Limit(erc20Guild.address, 0)
+                .executeUpdateERC20Limit(erc20Guild.address, 0)
                 .encodeABI(),
             ],
             value: [0, 0],
@@ -1652,7 +1652,7 @@ contract("ERC20Guild", function (accounts) {
                 .setETHPermissionDelay(erc20Guild.address, 60 * 10)
                 .encodeABI(),
               await new web3.eth.Contract(PermissionRegistry.abi).methods
-                .removeERC20Limit(erc20Guild.address, 0)
+                .updateERC20Limit(erc20Guild.address, 0, 0)
                 .encodeABI(),
             ],
             value: [0, 0],
@@ -1722,7 +1722,7 @@ contract("ERC20Guild", function (accounts) {
             to: [permissionRegistry.address, testToken.address],
             data: [
               await new web3.eth.Contract(PermissionRegistry.abi).methods
-                .executeRemoveERC20Limit(erc20Guild.address, 0)
+                .executeUpdateERC20Limit(erc20Guild.address, 0)
                 .encodeABI(),
               await new web3.eth.Contract(ERC20Mock.abi).methods
                 .transfer(accounts[3], 250)


### PR DESCRIPTION
[removeERC20Limit()](https://github.com/DXgovernance/dxdao-contracts/blob/0867dbaf13b26d92bd2af73059ed230887e58dcb/contracts/utils/PermissionRegistry.sol#L148-L155) sets a delay to the actual removal of the limit, which will be executed by calling `executeRemoveERC20Limit()`. However, currently  the [execution is allowed](https://github.com/DXgovernance/dxdao-contracts/blob/0867dbaf13b26d92bd2af73059ed230887e58dcb/contracts/utils/PermissionRegistry.sol#L164) UNTIL the delay has passed instead of ONCE the delay has passed.