### PR TITLE
Implement Multivote onchain

### DIFF
--- a/contracts/erc20guild/BaseERC20Guild.sol
+++ b/contracts/erc20guild/BaseERC20Guild.sol
@@ -727,17 +727,27 @@ contract BaseERC20Guild {
         return result;
     }
 
-    function _validateVote(bytes32 proposalId, uint256 option, uint256 votingPower) private view returns (VoteResult memory) {
+    function _validateVote(
+        bytes32 proposalId,
+        uint256 option,
+        uint256 votingPower
+    ) private view returns (VoteResult memory) {
         VoteResult memory result;
         result.success = true;
 
         if (proposals[proposalId].endTime < block.timestamp) {
             result.success = false;
             result.error = "ERC20Guild: Proposal ended, cannot be voted";
-        } else if (votingPowerOf(msg.sender) < votingPower || votingPower < proposalVotes[proposalId][msg.sender].votingPower) {
+        } else if (
+            votingPowerOf(msg.sender) < votingPower || votingPower < proposalVotes[proposalId][msg.sender].votingPower
+        ) {
             result.success = false;
             result.error = "ERC20Guild: Invalid votingPower amount";
-        } else if (proposalVotes[proposalId][msg.sender].votingPower > votingPower && (proposalVotes[proposalId][msg.sender].option != option && proposalVotes[proposalId][msg.sender].votingPower > votingPower) ) {
+        } else if (
+            proposalVotes[proposalId][msg.sender].votingPower > votingPower &&
+            (proposalVotes[proposalId][msg.sender].option != option &&
+                proposalVotes[proposalId][msg.sender].votingPower > votingPower)
+        ) {
             result.success = false;
             result.error = "ERC20Guild: Cannot change option voted, only increase votingPower";
         }

--- a/contracts/erc20guild/IERC20Guild.sol
+++ b/contracts/erc20guild/IERC20Guild.sol
@@ -182,4 +182,38 @@ interface IERC20Guild {
         uint256 option,
         uint256 votingPower
     ) external pure returns (bytes32);
+
+    function validateMerkleTreeLeaf(
+        bytes32 root,
+        bytes32 voteHash,
+        bytes32[] memory proof
+    ) external returns (bool);
+
+    function executeSignedVote(
+        bytes32 rootHash,
+        address voter,
+        bytes32 voteHash,
+        bytes32[] memory proof,
+        bytes32 proposalId,
+        uint256 option,
+        uint256 votingPower,
+        bytes memory signature
+    ) external;
+
+    function executeSignedVotesBatches(
+        bytes32[] memory roots,
+        address[] memory voters,
+        bytes32[] memory votesHashes,
+        bytes32[][] memory proofs,
+        bytes32[] memory proposalIds,
+        uint256[] memory options,
+        uint256[] memory votingPowers,
+        bytes[] memory signatures
+    ) external;
+
+    function setMultipleVotes(
+        bytes32[] memory proposalIds,
+        uint256[] memory options,
+        uint256[] memory votingPowers
+    ) external returns (bool[] memory);
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "hardhat-gas-reporter": "^1.0.4",
     "husky": "^7.0.4",
     "lint-staged": "^12.3.4",
+    "merkletreejs": "^0.3.9",
     "pm2": "^2.9.3",
     "promisify": "^0.0.3",
     "pug": "^2.0.0-rc.4",

--- a/test/deploy/dxgovGuild.test.js
+++ b/test/deploy/dxgovGuild.test.js
@@ -106,4 +106,3 @@ describe.skip("DXgovGuild deploy script", function () {
     expect(permis.valueAllowed.toString()).equal(hre.web3.utils.toWei("10000"));
   });
 });
-

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -2882,7 +2882,7 @@ contract("ERC20Guild", function (accounts) {
       );
     });
   });
-  describe.only("Multivote", function () {
+  describe("Multivote", function () {
     let proposalId1, proposalId2, proposalId3, votes, voter;
     beforeEach(async function () {
       proposalId1 = await createProposal(genericProposal);

--- a/test/erc20guild/ERC20Guild.js
+++ b/test/erc20guild/ERC20Guild.js
@@ -1,5 +1,7 @@
 import { web3 } from "@openzeppelin/test-helpers/src/setup";
 import { assert, expect } from "chai";
+import MerkleTree from "merkletreejs";
+import { utils } from "ethers";
 import * as helpers from "../helpers";
 const { fixSignature } = require("../helpers/sign");
 const {
@@ -2521,6 +2523,408 @@ contract("ERC20Guild", function (accounts) {
         ),
         "ERC20Guild: Wrong signer"
       );
+    });
+  });
+  describe("Offchain voting", () => {
+    let votingData;
+    beforeEach(async () => {
+      await lockTokens();
+
+      const voter = accounts[1];
+      const votingPower = await erc20Guild.votingPowerOf(voter);
+      const option = "1";
+
+      const firstProposalId = await createProposal(genericProposal);
+      const secondProposalId = await createProposal(genericProposal);
+
+      const firstVoteHash = await erc20Guild.hashVote(
+        voter,
+        firstProposalId,
+        option,
+        votingPower.toString()
+      );
+
+      const secondVoteHash = await erc20Guild.hashVote(
+        voter,
+        secondProposalId,
+        option,
+        votingPower.toString()
+      );
+
+      const leaves = [firstVoteHash, secondVoteHash];
+
+      const tree = new MerkleTree(leaves, utils.keccak256, {
+        sort: true,
+      });
+
+      const root = tree.getHexRoot();
+
+      votingData = {
+        tree,
+        root,
+        voter,
+        voteHashes: [firstVoteHash, secondVoteHash],
+        proposalIds: [firstProposalId, secondProposalId],
+        option,
+        votingPower: votingPower,
+      };
+    });
+
+    it("Should execute one signed vote", async () => {
+      const proof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+
+      await erc20Guild.executeSignedVote(
+        votingData.root,
+        votingData.voter,
+        votingData.voteHashes[1],
+        proof,
+        votingData.proposalIds[1],
+        votingData.option,
+        votingData.votingPower,
+        signature
+      );
+
+      const proposal = await erc20Guild.getProposal(votingData.proposalIds[1]);
+
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[1])).equal(
+        true
+      );
+      expect(proposal.totalVotes[1]).to.equal(
+        votingData.votingPower.toString()
+      );
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[0])).equal(
+        false
+      );
+    });
+
+    it("Should execute multiple signed votes from same tree", async () => {
+      const firstProof = votingData.tree.getHexProof(votingData.voteHashes[0]);
+      const secondProof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+
+      await erc20Guild.executeSignedVotesBatches(
+        [votingData.root, votingData.root],
+        [votingData.voter, votingData.voter],
+        [votingData.voteHashes[0], votingData.voteHashes[1]],
+        [firstProof, secondProof],
+        [votingData.proposalIds[0], votingData.proposalIds[1]],
+        [votingData.option, votingData.option],
+        [votingData.votingPower, votingData.votingPower],
+        [signature, signature]
+      );
+
+      const firstProposal = await erc20Guild.getProposal(
+        votingData.proposalIds[0]
+      );
+      const secondProposal = await erc20Guild.getProposal(
+        votingData.proposalIds[1]
+      );
+
+      expect(firstProposal.totalVotes[votingData.option]).to.equal(
+        votingData.votingPower.toString()
+      );
+      expect(secondProposal.totalVotes[votingData.option]).to.equal(
+        votingData.votingPower.toString()
+      );
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[0])).equal(
+        true
+      );
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[1])).equal(
+        true
+      );
+    });
+
+    it("Should execute multiple signed votes from diff trees/voter", async () => {
+      const voter3 = accounts[2];
+      const votingPower2 = await erc20Guild.votingPowerOf(voter3);
+      const option = "1";
+
+      const thirdProposalId = await createProposal(genericProposal);
+
+      const voteHash3 = await erc20Guild.hashVote(
+        voter3,
+        thirdProposalId,
+        option,
+        votingPower2.toString()
+      );
+
+      const leaves = [voteHash3];
+
+      const tree = new MerkleTree(leaves, utils.keccak256, {
+        sort: true,
+      });
+
+      const root3 = tree.getHexRoot();
+
+      const firstProof = votingData.tree.getHexProof(votingData.voteHashes[0]);
+      const secondProof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+      const thirdProof = votingData.tree.getHexProof(voteHash3);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+      const signature2 = fixSignature(await web3.eth.sign(root3, voter3));
+
+      await erc20Guild.executeSignedVotesBatches(
+        [root3, votingData.root, votingData.root],
+        [voter3, votingData.voter, votingData.voter],
+        [voteHash3, votingData.voteHashes[0], votingData.voteHashes[1]],
+        [thirdProof, firstProof, secondProof],
+        [thirdProposalId, votingData.proposalIds[0], votingData.proposalIds[1]],
+        [option, votingData.option, votingData.option],
+        [votingPower2, votingData.votingPower, votingData.votingPower],
+        [signature2, signature, signature]
+      );
+
+      const firstProposal = await erc20Guild.getProposal(
+        votingData.proposalIds[0]
+      );
+      const secondProposal = await erc20Guild.getProposal(
+        votingData.proposalIds[1]
+      );
+      const thirdProposal = await erc20Guild.getProposal(thirdProposalId);
+
+      expect(firstProposal.totalVotes[votingData.option]).to.equal(
+        votingData.votingPower.toString()
+      );
+      expect(secondProposal.totalVotes[votingData.option]).to.equal(
+        votingData.votingPower.toString()
+      );
+      expect(thirdProposal.totalVotes[option]).to.equal(
+        votingPower2.toString()
+      );
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[0])).equal(
+        true
+      );
+      expect(await erc20Guild.getSignedVote(votingData.voteHashes[1])).equal(
+        true
+      );
+      expect(await erc20Guild.getSignedVote(voteHash3)).equal(true);
+    });
+
+    it("Should revert if hash is invalid", async () => {
+      const invalidHash = await erc20Guild.hashVote(
+        votingData.voter,
+        votingData.proposalIds[1],
+        "2", // invalid option
+        votingData.votingPower.toString()
+      );
+      const proof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          votingData.root,
+          votingData.voter,
+          invalidHash,
+          proof,
+          votingData.proposalIds[1],
+          votingData.option,
+          votingData.votingPower,
+          signature
+        ),
+        "ERC20Guild: Invalid vote hash"
+      );
+    });
+
+    it("Should revert if vote was already voted", async () => {
+      const proof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+
+      await erc20Guild.executeSignedVote(
+        votingData.root,
+        votingData.voter,
+        votingData.voteHashes[1],
+        proof,
+        votingData.proposalIds[1],
+        votingData.option,
+        votingData.votingPower,
+        signature
+      );
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          votingData.root,
+          votingData.voter,
+          votingData.voteHashes[1],
+          proof,
+          votingData.proposalIds[1],
+          votingData.option,
+          votingData.votingPower,
+          signature
+        ),
+        "ERC20Guild: Already voted"
+      );
+    });
+
+    it("Should revert if signer is invalid", async () => {
+      const invalidSigner = accounts[8];
+      const proof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, invalidSigner)
+      );
+
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          votingData.root,
+          votingData.voter,
+          votingData.voteHashes[1],
+          proof,
+          votingData.proposalIds[1],
+          votingData.option,
+          votingData.votingPower,
+          signature
+        ),
+        "ERC20Guild: Wrong signer"
+      );
+    });
+
+    it("Should revert if merkletree is invalid", async () => {
+      const invalidHash = await erc20Guild.hashVote(
+        votingData.voter,
+        votingData.proposalIds[1],
+        "2", // invalid option
+        votingData.votingPower.toString()
+      );
+
+      const invalidProof = votingData.tree.getHexProof(invalidHash);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          votingData.root,
+          votingData.voter,
+          votingData.voteHashes[1],
+          invalidProof, // invalid proof
+          votingData.proposalIds[1],
+          votingData.option,
+          votingData.votingPower,
+          signature
+        ),
+        "ERC20Guild: Invalid merkle tree leaf"
+      );
+    });
+
+    it("Should revert if proposal ended", async () => {
+      await time.increase(40);
+      const proof = votingData.tree.getHexProof(votingData.voteHashes[1]);
+
+      const signature = fixSignature(
+        await web3.eth.sign(votingData.root, votingData.voter)
+      );
+
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          votingData.root,
+          votingData.voter,
+          votingData.voteHashes[1],
+          proof,
+          votingData.proposalIds[1],
+          votingData.option,
+          votingData.votingPower,
+          signature
+        ),
+        "ERC20Guild: Proposal ended, cannot be voted"
+      );
+    });
+
+    it("Should revert if vote has invalid VotingPower", async () => {
+      const voter = accounts[2];
+      const votingPower =
+        (await erc20Guild.votingPowerOf(voter)).toNumber() + 5000;
+      const option = "1";
+
+      const proposalId = await createProposal(genericProposal);
+
+      const voteHash = await erc20Guild.hashVote(
+        voter,
+        proposalId,
+        option,
+        votingPower.toString()
+      );
+      const leaves = [voteHash];
+
+      const root = new MerkleTree(leaves, utils.keccak256, {
+        sort: true,
+      }).getHexRoot();
+
+      const proof = votingData.tree.getHexProof(voteHash);
+
+      const signature = fixSignature(await web3.eth.sign(root, voter));
+
+      await expectRevert(
+        erc20Guild.executeSignedVote(
+          root,
+          voter,
+          voteHash,
+          proof,
+          proposalId,
+          option,
+          votingPower,
+          signature
+        ),
+        "ERC20Guild: Invalid votingPower amount"
+      );
+    });
+  });
+  describe.only("Multivote", function () {
+    let proposalId1, proposalId2, proposalId3, votes, voter;
+    beforeEach(async function () {
+      proposalId1 = await createProposal(genericProposal);
+      proposalId2 = await createProposal(genericProposal);
+      proposalId3 = await createProposal(genericProposal);
+
+      voter = accounts[2];
+      const voterPower = await erc20Guild.votingPowerOf(voter);
+      votes = [
+        {
+          proposalId: proposalId1,
+          option: "1",
+          votingPower: voterPower.toString(),
+        },
+        {
+          proposalId: proposalId2,
+          option: "0",
+          votingPower: voterPower.toString(),
+        },
+        {
+          proposalId: proposalId3,
+          option: "1",
+          votingPower: voterPower.toString(),
+        },
+      ];
+    });
+
+    it("Should set multiple votes", async function () {
+      const proposalIds = votes.map(v => v.proposalId);
+      const options = votes.map(v => v.option);
+      const votingPower = votes.map(v => v.votingPower);
+
+      await erc20Guild.setMultipleVotes(proposalIds, options, votingPower, {
+        from: voter,
+      });
+
+      for (const vote of votes) {
+        const proposal = await erc20Guild.getProposal(vote.proposalId);
+        expect(proposal.totalVotes[vote.option].toString()).to.equal(
+          vote.votingPower
+        );
+      }
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,6 +6178,11 @@ buffer-pipe@0.0.3:
   dependencies:
     safe-buffer "^5.1.2"
 
+buffer-reverse@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-reverse/-/buffer-reverse-1.0.1.tgz#49283c8efa6f901bc01fa3304d06027971ae2f60"
+  integrity sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==
+
 buffer-to-arraybuffer@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz#6064a40fa76eb43c723aba9ef8f6e1216d10511a"
@@ -7334,6 +7339,11 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^3.1.9-1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
+  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
 css-select@^4.1.3:
   version "4.1.3"
@@ -14255,6 +14265,17 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     rlp "^2.0.0"
     semaphore ">=1.0.1"
 
+merkletreejs@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/merkletreejs/-/merkletreejs-0.3.9.tgz#cdb364a3b974a44f4eff3446522d7066e0cf95de"
+  integrity sha512-NjlATjJr4NEn9s8v/VEHhgwRWaE1eA/Une07d9SEqKzULJi1Wsh0Y3svwJdP2bYLMmgSBHzOrNydMWM1NN9VeQ==
+  dependencies:
+    bignumber.js "^9.0.1"
+    buffer-reverse "^1.0.1"
+    crypto-js "^3.1.9-1"
+    treeify "^1.1.0"
+    web3-utils "^1.3.4"
+
 meros@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.1.4.tgz#c17994d3133db8b23807f62bec7f0cb276cfd948"
@@ -19327,6 +19348,11 @@ tr46@~0.0.1, tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+treeify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
+  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -21144,7 +21170,7 @@ web3-utils@1.6.0, web3-utils@^1.0.0-beta.31, web3-utils@^1.2.5:
     randombytes "^2.1.0"
     utf8 "3.0.0"
 
-web3-utils@1.8.1:
+web3-utils@1.8.1, web3-utils@^1.3.4:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.8.1.tgz#f2f7ca7eb65e6feb9f3d61056d0de6bbd57125ff"
   integrity sha512-LgnM9p6V7rHHUGfpMZod+NST8cRfGzJ1BTXAyNo7A9cJX9LczBfSRxJp+U/GInYe9mby40t3v22AJdlELibnsQ==


### PR DESCRIPTION
## Summary
This was part of work done in Infinite hackathon last October. The idea behind this was to extend `BaseERC20Guild` contract: 
- To have a "multivote" functionality allowing the user to vote in multiple proposals at once.
- To have a way of executing votes in behalf of someone else with their signature. 


### Vote batching:
A user can send an array of votes to be executed, allowing the voting of multiple proposals in just one transaction. This mechanism works both for on- and off-chain voting (`setMultipleVotes` and `executeSignedVotesBatches` respectively).

### Off-chain signature voting:
A user can now sign a vote off-chain that another user can execute.

### Security features:
Each vote is part of a Merkle tree, allowing us to verify that the vote to be executed is indeed part of a block of votes. We do this using the MerkleProof smart contract by OpenZeppelin.

The voter must also sign the Merkle tree root hash. By doing this, the voter only needs to sign one message (the tree root) instead of every vote.

The combined mechanisms allow us to verify that a vote is part of a group of votes and that the voter indeed approves the group of votes.