### PR TITLE
Feat/dxdstake

### DIFF
--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -5,10 +5,9 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20Snapshot
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
- * @title TokenVault
- * @dev A smart contract to lock an ERC20 token in behalf of user trough an intermediary admin contract.
- * User -> Admin Contract -> Token Vault Contract -> Admin Contract -> User.
- * Tokens can be deposited and withdrawal only with authorization of the locker account from the admin address.
+ * @title DXDInfluence
+ * @dev Keeps track of the time commitment of accounts that have staked. The more DXD is staked and
+ * the more time the DXD tokens are staked, the more influence the user will have on the DAO. 
  */
 contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     using ArraysUpgradeable for uint256[];

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -30,6 +30,7 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
     function initialize(
         address _dxdStake,
+        address _votingPower,
         string memory name,
         string memory symbol
     ) external initializer {
@@ -38,6 +39,7 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         _transferOwnership(_dxdStake);
         dxdStake = ERC20SnapshotUpgradeable(_dxdStake);
+        votingPower = VotingPower(_votingPower);
     }
 
     /// @dev Not allow the transfer of tokens
@@ -47,10 +49,6 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
         uint256 amount
     ) internal virtual override {
         revert Influence__NoTransfer();
-    }
-
-    function changeVotingPowerContract(VotingPower _newVotingPower) external onlyOwner {
-        votingPower = _newVotingPower;
     }
 
     /// @dev Stakes tokens from the user.

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -92,4 +92,9 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         return registeredBalance + nonRegisteredBalance;
     }
+
+    /// @dev Get the current snapshotId
+    function getCurrentSnapshotId() external view returns (uint256) {
+        return _getCurrentSnapshotId();
+    }
 }

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.17;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
+interface VotingPower {
+    function callback(address _account) external;
+}
+
 /**
  * @title DXDInfluence
  * @dev Keeps track of the time commitment of accounts that have staked. The more DXD is staked and
@@ -13,6 +17,7 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     using ArraysUpgradeable for uint256[];
 
     ERC20SnapshotUpgradeable public dxdStake;
+    VotingPower public votingPower;
     mapping(address => uint256[]) public stakeTimes; // stakeTimes[account]
     mapping(uint256 => uint256) public snapshotTimes; // snapshotTimes[snapshotId]
 
@@ -55,6 +60,9 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
         _snapshot();
         stakeTimes[account].push(block.timestamp);
         snapshotTimes[_getCurrentSnapshotId()] = block.timestamp;
+
+        // Notify Voting Power contract.
+        votingPower.callback(msg.sender);
     }
 
     function totalSupply() public view virtual override returns (uint256) {

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -11,7 +11,8 @@ interface VotingPower {
 /**
  * @title DXDInfluence
  * @dev Keeps track of the time commitment of accounts that have staked. The more DXD is staked and
- * the more time the DXD tokens are staked, the more influence the user will have on the DAO. 
+ * the more time the DXD tokens are staked, the more influence the user will have on the DAO.
+ * DXDInfluence notifies the Voting Power contract of any stake changes.
  */
 contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     using ArraysUpgradeable for uint256[];
@@ -46,6 +47,10 @@ contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
         uint256 amount
     ) internal virtual override {
         revert Influence__NoTransfer();
+    }
+
+    function changeVotingPowerContract(VotingPower _newVotingPower) external onlyOwner {
+        votingPower = _newVotingPower;
     }
 
     /// @dev Stakes tokens from the user.

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/**
+ * @title TokenVault
+ * @dev A smart contract to lock an ERC20 token in behalf of user trough an intermediary admin contract.
+ * User -> Admin Contract -> Token Vault Contract -> Admin Contract -> User.
+ * Tokens can be deposited and withdrawal only with authorization of the locker account from the admin address.
+ */
+contract DXDInfluence is OwnableUpgradeable, ERC20SnapshotUpgradeable {
+    using ArraysUpgradeable for uint256[];
+
+    ERC20SnapshotUpgradeable public dxdStake;
+    mapping(address => uint256[]) public stakeTimes; // stakeTimes[account]
+    mapping(uint256 => uint256) public snapshotTimes; // snapshotTimes[snapshotId]
+
+    /// @notice Error when trying to transfer influence
+    error Influence__NoTransfer();
+
+    constructor() {}
+
+    function initialize(
+        address _dxdStake,
+        string memory name,
+        string memory symbol
+    ) external initializer {
+        __ERC20_init(name, symbol);
+        __Ownable_init();
+
+        _transferOwnership(_dxdStake);
+        dxdStake = ERC20SnapshotUpgradeable(_dxdStake);
+    }
+
+    /// @dev Not allow the transfer of tokens
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        revert Influence__NoTransfer();
+    }
+
+    /// @dev Stakes tokens from the user.
+    /// @param account Account that has staked the tokens.
+    /// @param amount Amount of tokens to have been staked.
+    function mint(address account, uint256 amount) external onlyOwner {
+        uint256 influenceUpdate;
+        if (stakeTimes[account].length > 0) {
+            uint256 lastStakeTime = stakeTimes[account][stakeTimes[account].length - 1];
+            influenceUpdate = dxdStake.balanceOf(account) * (block.timestamp - lastStakeTime);
+        }
+        _mint(account, influenceUpdate);
+        _snapshot();
+        stakeTimes[account].push(block.timestamp);
+        snapshotTimes[_getCurrentSnapshotId()] = block.timestamp;
+    }
+
+    function totalSupply() public view virtual override returns (uint256) {
+        uint256 registeredTotalSupply = super.totalSupply();
+        uint256 lastMint = snapshotTimes[_getCurrentSnapshotId()];
+        uint256 totalSupplyUpdate = dxdStake.totalSupply() * (block.timestamp - lastMint);
+
+        return registeredTotalSupply + totalSupplyUpdate;
+    }
+
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        uint256 registeredBalance = balanceOf(account);
+        uint256 lastStakeTime = stakeTimes[account][stakeTimes[account].length - 1];
+        uint256 nonRegisteredBalance = dxdStake.balanceOf(account) * (block.timestamp - lastStakeTime);
+
+        return registeredBalance + nonRegisteredBalance;
+    }
+
+    function balanceOfAt(address account, uint256 snapshotId) public view virtual override returns (uint256) {
+        uint256 registeredBalance = super.balanceOfAt(account, snapshotId);
+
+        uint256 snapshotTime = snapshotTimes[snapshotId];
+        uint256 index = stakeTimes[account].findUpperBound(snapshotTime);
+
+        uint256 nonRegisteredTime = snapshotTimes[snapshotId] - stakeTimes[account][index];
+        uint256 nonRegisteredBalance = dxdStake.balanceOfAt(account, snapshotId) * nonRegisteredTime;
+
+        return registeredBalance + nonRegisteredBalance;
+    }
+}

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -51,25 +51,25 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     /// @dev Stakes tokens from the user.
     /// @param _amount Amount of tokens to stake.
     function stake(uint256 _amount) external {
+        // Mint influence tokens.
+        dxdInfluence.mint(msg.sender, _amount);
+
         // Stake DXD tokens
         dxd.safeTransferFrom(msg.sender, address(this), _amount);
         _mint(msg.sender, _amount);
         _snapshot();
-
-        // Mint influence tokens.
-        dxdInfluence.mint(msg.sender, _amount);
     }
 
     /// @dev Withdraw the tokens to the user.
     /// @param _amount Amount of tokens to withdraw.
     function withdraw(uint256 _amount) external {
+        // Mint influence tokens.
+        dxdInfluence.mint(msg.sender, _amount);
+
         // Unstake DXD tokens
         dxd.safeTransfer(msg.sender, _amount);
         _burn(msg.sender, _amount);
         _snapshot();
-
-        // Mint influence tokens.
-        dxdInfluence.mint(msg.sender, _amount);
     }
 
     /// @dev Get the current snapshotId

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+interface VotingPower {
+    function callback(address _account) external;
+}
+
+/**
+ * @title DXDStake
+ * @dev DXD wrapper contract. DXD tokens converted into DXDStake tokens get locked and are not transferable.
+ * DXDStake notifies the Voting Power contract of any stake changes. 
+ */
+contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    IERC20Upgradeable public dxd;
+    VotingPower public votingPower;
+
+    /// @notice Error when trying to transfer reputation
+    error DXDStake__NoTransfer();
+
+    constructor() {}
+
+    function initialize(address _dxd, address _owner, string memory name, string memory symbol) external initializer {
+        __ERC20_init(name, symbol);
+        __Ownable_init();
+
+        _transferOwnership(_owner);
+        dxd = IERC20Upgradeable(_dxd);
+    }
+
+    function changeVotingPowerContract(VotingPower _newVotingPower) external onlyOwner {
+        votingPower = _newVotingPower;
+    }
+
+    /// @dev Not allow the transfer of tokens
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        revert DXDStake__NoTransfer();
+    }
+    
+
+    /// @dev Stakes tokens from the user.
+    /// @param _amount Amount of tokens to stake.
+    function stake(uint256 _amount) external {
+        dxd.safeTransferFrom(msg.sender, address(this), _amount);
+        _mint(msg.sender, _amount);
+        _snapshot();
+        votingPower.callback(msg.sender);
+    }
+
+    /// @dev Withdraw the tokens to the user.
+    /// @param _amount Amount of tokens to withdraw.
+    function withdraw(uint256 _amount) external {
+        dxd.safeTransfer(msg.sender, _amount);
+        _burn(msg.sender, _amount);
+        _snapshot();
+        votingPower.callback(msg.sender);
+    }
+}

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -6,10 +6,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20Snapshot
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./DXDInfluence.sol";
 
-interface VotingPower {
-    function callback(address _account) external;
-}
-
 /**
  * @title DXDStake
  * @dev DXD wrapper contract. DXD tokens converted into DXDStake tokens get locked and are not transferable.
@@ -19,7 +15,6 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     IERC20Upgradeable public dxd;
-    VotingPower public votingPower;
     DXDInfluence public dxdInfluence;
 
     /// @notice Error when trying to transfer reputation
@@ -63,9 +58,6 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         // Mint influence tokens.
         dxdInfluence.mint(msg.sender, _amount);
-
-        // Notify Voting Power contract.
-        votingPower.callback(msg.sender);
     }
 
     /// @dev Withdraw the tokens to the user.
@@ -78,8 +70,5 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         // Mint influence tokens.
         dxdInfluence.mint(msg.sender, _amount);
-
-        // Notify Voting Power contract.
-        votingPower.callback(msg.sender);
     }
 }

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -23,6 +23,7 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
     function initialize(
         address _dxd,
+        address _dxdInfluence,
         address _owner,
         string memory name,
         string memory symbol
@@ -32,6 +33,7 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         _transferOwnership(_owner);
         dxd = IERC20Upgradeable(_dxd);
+        dxdInfluence = DXDInfluence(_dxdInfluence);
     }
 
     /// @dev Not allow the transfer of tokens

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -9,7 +9,6 @@ import "./DXDInfluence.sol";
 /**
  * @title DXDStake
  * @dev DXD wrapper contract. DXD tokens converted into DXDStake tokens get locked and are not transferable.
- * DXDStake notifies the Voting Power contract of any stake changes.
  */
 contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -33,10 +32,6 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
 
         _transferOwnership(_owner);
         dxd = IERC20Upgradeable(_dxd);
-    }
-
-    function changeVotingPowerContract(VotingPower _newVotingPower) external onlyOwner {
-        votingPower = _newVotingPower;
     }
 
     /// @dev Not allow the transfer of tokens

--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -71,4 +71,9 @@ contract DXDStake is OwnableUpgradeable, ERC20SnapshotUpgradeable {
         // Mint influence tokens.
         dxdInfluence.mint(msg.sender, _amount);
     }
+
+    /// @dev Get the current snapshotId
+    function getCurrentSnapshotId() external view returns (uint256) {
+        return _getCurrentSnapshotId();
+    }
 }

--- a/contracts/test/VotingPowerMock.sol
+++ b/contracts/test/VotingPowerMock.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.17;
+
+// mock class using ERC20
+contract VotingPowerMock {
+    constructor() {}
+
+    function callback(address account) external {}
+}


### PR DESCRIPTION
The DXDStake token is a DXD wrapper that adds snapshots and non-transferability to the original DXD token contract.
The DXDInfluence token is a DXDStake proxy that adds complexity to the DXD staking formula and interacts with the Voting Power contract. The formula, if used, will likely depend on time (i.e. the more time someone stakes their tokens, the more influence they will have on the DAO)