### PR TITLE
VotingMachine: add getProposalTimes function

### DIFF
--- a/contracts/dao/votingMachine/VotingMachine.sol
+++ b/contracts/dao/votingMachine/VotingMachine.sol
@@ -1272,4 +1272,13 @@ contract VotingMachine {
     function multiplyRealMath(uint256 a, uint256 b) public pure returns (uint256) {
         return a.mul(b);
     }
+
+    /**
+     * @dev Returns proposal `times` property for given `proposalId`
+     * @param proposalId Id of the proposal
+     * @return times proposal.times [submittedTime, boostedPhaseTime, preBoostedPhaseTime]
+     */
+    function getProposalTimes(bytes32 proposalId) public view returns (uint256[3] memory times) {
+        return proposals[proposalId].times;
+    }
 }


### PR DESCRIPTION
When retrieving the proposal data for the subgraph, it doesn't return the times array (https://github.com/ethereum/solidity/issues/12863), so this pr is to add a getter function to retrieve proposal.times.