### PR TITLE
fix: total supply influence on formula update

### DIFF
--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -92,11 +92,12 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
      */
     function changeFormula(int256 _linearMultiplier, int256 _exponentialMultiplier) external onlyOwner {
         uint256 currentSnapshotId = _snapshot(FORMULA_SNAPSHOT_SLOT);
-        formulaMultipliers[currentSnapshotId].linearMultiplier = SD59x18.wrap(_linearMultiplier);
-        formulaMultipliers[currentSnapshotId].exponentialMultiplier = SD59x18.wrap(_exponentialMultiplier);
+        FormulaMultipliers storage newFormula = formulaMultipliers[currentSnapshotId];
+        newFormula.linearMultiplier = SD59x18.wrap(_linearMultiplier);
+        newFormula.exponentialMultiplier = SD59x18.wrap(_exponentialMultiplier);
 
         // Update global stake data
-        _totalInfluenceSnapshots[currentSnapshotId] = _totalInfluenceSnapshots[currentSnapshotId - 1];
+        _totalInfluenceSnapshots[currentSnapshotId] = calculateInfluence(totalCumulativeStake, newFormula);
     }
 
     /**

--- a/contracts/dao/DXDInfluence.sol
+++ b/contracts/dao/DXDInfluence.sol
@@ -113,12 +113,10 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
         uint256 _amount,
         uint256 _timeCommitment
     ) external onlyOwner {
-        CumulativeStake storage lastCumulativeStake = getLastCumulativeStake(_account);
+        CumulativeStake storage lastCumulativeStake = cumulativeStakesSnapshots[_account][_lastSnapshotId(_account)];
         uint256 currentSnapshotId = _snapshot(_account);
 
-        UD60x18 tc = toUD60x18(_timeCommitment);
-        uint256 exponentialTerm = fromUD60x18(toUD60x18(_amount).mul(tc.pow(exponent)));
-        uint256 linearTerm = _amount * _timeCommitment;
+        (uint256 linearTerm, uint256 exponentialTerm) = getFormulaTerms(_amount, _timeCommitment);
 
         // Update account's stake data
         CumulativeStake storage cumulativeStake = cumulativeStakesSnapshots[_account][currentSnapshotId];
@@ -148,12 +146,10 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
         uint256 _amount,
         uint256 _timeCommitment
     ) external onlyOwner {
-        CumulativeStake storage lastCumulativeStake = getLastCumulativeStake(_account);
+        CumulativeStake storage lastCumulativeStake = cumulativeStakesSnapshots[_account][_lastSnapshotId(_account)];
         uint256 currentSnapshotId = _snapshot(_account);
 
-        UD60x18 tc = toUD60x18(_timeCommitment);
-        uint256 exponentialTerm = fromUD60x18(toUD60x18(_amount).mul(tc.pow(exponent)));
-        uint256 linearTerm = _amount * _timeCommitment;
+        (uint256 linearTerm, uint256 exponentialTerm) = getFormulaTerms(_amount, _timeCommitment);
 
         // Update account's stake data
         CumulativeStake storage cumulativeStake = cumulativeStakesSnapshots[_account][currentSnapshotId];
@@ -185,16 +181,11 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
         uint256 _oldTimeCommitment,
         uint256 _newTimeCommitment
     ) external onlyOwner {
-        CumulativeStake storage lastCumulativeStake = getLastCumulativeStake(_account);
+        CumulativeStake storage lastCumulativeStake = cumulativeStakesSnapshots[_account][_lastSnapshotId(_account)];
         uint256 currentSnapshotId = _snapshot(_account);
 
-        UD60x18 oldTc = toUD60x18(_oldTimeCommitment);
-        uint256 oldExponentialTerm = fromUD60x18(toUD60x18(_amount).mul(oldTc.pow(exponent)));
-        uint256 oldLinearTerm = _amount * _oldTimeCommitment;
-
-        UD60x18 newTc = toUD60x18(_newTimeCommitment);
-        uint256 newExponentialTerm = fromUD60x18(toUD60x18(_amount).mul(newTc.pow(exponent)));
-        uint256 newLinearTerm = _amount * _newTimeCommitment;
+        (uint256 oldLinearTerm, uint256 oldExponentialTerm) = getFormulaTerms(_amount, _oldTimeCommitment);
+        (uint256 newLinearTerm, uint256 newExponentialTerm) = getFormulaTerms(_amount, _newTimeCommitment);
 
         // Update account's stake data
         CumulativeStake storage cumulativeStake = cumulativeStakesSnapshots[_account][currentSnapshotId];
@@ -215,11 +206,15 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
     }
 
     /**
-     * @dev Returns the last snapshot Id registered for a given account.
-     * @param _account Account that has staked.
+     * @dev Returns the linear and exponential influence term for a given amount and time commitment.
+     * @param _amount DXD amount.
+     * @param _timeCommitment Amount of time the DXD is staked.
      */
-    function getLastCumulativeStake(address _account) internal view returns (CumulativeStake storage) {
-        return cumulativeStakesSnapshots[_account][_lastSnapshotId(_account)];
+    function getFormulaTerms(uint256 _amount, uint256 _timeCommitment) internal view returns (uint256, uint256) {
+        UD60x18 tc = toUD60x18(_timeCommitment);
+        uint256 exponentialTerm = fromUD60x18(toUD60x18(_amount).mul(tc.pow(exponent)));
+        uint256 linearTerm = _amount * _timeCommitment;
+        return (linearTerm, exponentialTerm);
     }
 
     /**
@@ -240,7 +235,7 @@ contract DXDInfluence is OwnableUpgradeable, AccountSnapshot {
      * @dev Returns the amount of influence owned by `account`.
      */
     function balanceOf(address account) public view returns (uint256) {
-        CumulativeStake storage cumulativeStake = getLastCumulativeStake(account);
+        CumulativeStake storage cumulativeStake = cumulativeStakesSnapshots[account][_lastSnapshotId(account)];
         return calculateInfluence(cumulativeStake, formulaMultipliers[_lastSnapshotId(FORMULA_SNAPSHOT_SLOT)]);
     }
 

--- a/test/dao/DXDStake.js
+++ b/test/dao/DXDStake.js
@@ -521,11 +521,9 @@ contract("DXD staking and DXD influence", async accounts => {
       const newLF = -0.1;
       const newLinearFactor = web3.utils.toWei(newLF.toString(), "ether");
       await expectRevert(
-        dxdStake.changeInfluenceFormula(
-          newLinearFactor,
-          exponentialFactor,
-          { from: accounts[0] }
-        ),
+        dxdStake.changeInfluenceFormula(newLinearFactor, exponentialFactor, {
+          from: accounts[0],
+        }),
         "DXDInfluence: negative influence, update formula"
       );
 
@@ -570,7 +568,7 @@ contract("DXD staking and DXD influence", async accounts => {
       const influenceBalance3 = await dxdInfluence.balanceOf(dxdHolder);
       expect(influenceBalance3).to.be.bignumber.equal(influenceBalanceAt3);
       expect(influenceBalance3).to.be.bignumber.gt(influenceBalance2);
-      
+
       const totalSupplyAt3 = await dxdInfluence.totalSupplyAt(3);
       const totalSupply3 = await dxdInfluence.totalSupply();
       expect(totalSupply3).to.be.bignumber.equal(totalSupplyAt3);


### PR DESCRIPTION
When the influence formula is updated, a snapshot was being taken and the total supply at this snapshot was incorrect. The influence with the previous formula was used instead of using the newer one.