### PR TITLE
Feat/transfer stake

### DIFF
--- a/contracts/dao/DXDStake.sol
+++ b/contracts/dao/DXDStake.sol
@@ -157,33 +157,35 @@ contract DXDStake is OwnableUpgradeable, OptimizedERC20SnapshotUpgradeable {
      * @dev Transfers a commitment. The recipient gets the voting power rights that come from DXDInfluence
      * and can claim the locked DXD once the stakes completes.
      * @param _commitmentId Id of the commitment. The Id is an incremental variable for each account.
+     * @param _amount How much of the stake to transfer.
      * @param _to Address that the stake commitment will be transferred to.
      */
-    function transferCommitment(uint256 _commitmentId, address _to) external {
+    function transferCommitment(uint256 _commitmentId, uint176 _amount, address _to) external {
         StakeCommitment storage stakeCommitment = stakeCommitments[msg.sender][_commitmentId];
         require(stakeCommitment.commitmentEnd != 0, "DXDStake: commitment inactive");
 
         // Set new commitment
         StakeCommitment storage newStakeCommitment = stakeCommitments[_to].push();
-        newStakeCommitment.stake = stakeCommitment.stake;
+        newStakeCommitment.stake = _amount;
         newStakeCommitment.timeCommitment = stakeCommitment.timeCommitment;
         newStakeCommitment.commitmentEnd = stakeCommitment.commitmentEnd;
 
         // Transfer influence.
-        dxdInfluence.transfer(msg.sender, _to, stakeCommitment.stake, stakeCommitment.timeCommitment);
+        dxdInfluence.transfer(msg.sender, _to, _amount, stakeCommitment.timeCommitment);
 
         // Transfer staked DXD tokens.
-        _burn(msg.sender, stakeCommitment.stake);
-        _snapshot();
-        _mint(_to, stakeCommitment.stake);
+        _burn(msg.sender, _amount);
+        _mint(_to, _amount);
         _snapshot();
 
-        // Clean old commitment.
-        stakeCommitment.stake = 0;
-        stakeCommitment.timeCommitment = 0;
-        stakeCommitment.commitmentEnd = 0;
-        userWithdrawals[msg.sender] += 1;
-        totalWithdrawals += 1;
+        stakeCommitment.stake -= _amount;
+        if (stakeCommitment.stake == 0) {
+            // Clean old commitment.
+            stakeCommitment.timeCommitment = 0;
+            stakeCommitment.commitmentEnd = 0;
+            userWithdrawals[msg.sender] += 1;
+            totalWithdrawals += 1;
+        }
     }
 
     /**


### PR DESCRIPTION
Stakes will likely be traded in secondary markets at some point, even if DXDStake is not transferrable, and that's ok. Taking into account that it's not possible to enforce at the smart contract level the non-transferability of stakes, it could be a good feature to add transfer and approval functions to stakes.

With or without this feature, we should also reconsider if permissionless withdrawals are needed or not (see #322). I think that using, selling or lending DXD influence and immediately withdrawing is a security risk, especially if there is a chance that a big percentage of DXD influence end up having this property. The DXD influence someone gets by owning locked DXD is not just a reward for having staked, but it's a way to incentivize long-term decision making. If at some point most stakers end up having DXD influence that is not attached to locked DXD but to liquid DXD, governance might weaken and the incentive that new holders have to stake will decrease (why would you lock a significant amount of DXD for years if most of the voting power can exit immediately anytime?).

Waiting for feedback before implementing these features further (approvals and tests were not implemented yet). 